### PR TITLE
docs: add business focal point docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Dateflow owns the planning layer that every dating app abandons — the gap betw
 - [Implementation Guide — architecture, distributed systems, swipe algorithm, data model](docs/planning/implementation.md)
 - [User Stories — INVEST-evaluated backlog](docs/planning/user-stories.md)
 
+### [`docs/business/`](docs/business/) — Business strategy and team operations
+- [User Acquisition Strategy — tiered playbook for 100 session pairs](docs/business/user-acquisition-strategy.md)
+- [Team Tooling — GitHub Projects setup and alternatives](docs/business/team-tooling.md)
+- [First Sprint — pre-launch and launch week task checklist](docs/business/first-sprint.md)
+
 ### [`docs/dev-specs/`](docs/dev-specs/) — Implementation specifications
 - [Onboarding Summary — start here](docs/dev-specs/onboarding.md)
 - [Full Index — class registry, API registry, state machine](docs/dev-specs/index.md)

--- a/docs/business/first-sprint.md
+++ b/docs/business/first-sprint.md
@@ -1,0 +1,71 @@
+# Dateflow — Business Team First Sprint
+
+## Context
+
+The consumer demo is a sales tool for B2B partnerships. The business team's job in the first sprint is to prepare everything needed so that on launch day, the product has users waiting to try it and the acquisition channels are primed.
+
+This sprint runs **in parallel with MVP development** — not after it.
+
+---
+
+## Pre-Launch Tasks (Before MVP Goes Live)
+
+### Research & List Building
+
+- [ ] **Build a target list of 50 people in your network who are actively dating** — names, platform to reach them (text, Instagram, etc.), and when to ask. Prioritize people who would genuinely use this, not just supportive friends.
+- [ ] **Identify 10 Reddit threads from the last 30 days** where the planning problem is described — bookmark URLs for post-launch commenting. Subreddits: r/hingeapp, r/Tinder, r/dating_advice, r/datingoverthirty, r/bumble.
+- [ ] **Find 5 dating content creators** (TikTok/Instagram Reels, 50K–200K followers) who have posted about first date planning struggles — compile a DM outreach list with handles, follower counts, and links to relevant content.
+- [ ] **Research 3 press contacts** at dating or women's lifestyle outlets who have covered dating app stories in the last 6 months — names, outlets, and contact info.
+- [ ] **Identify 3 dating-focused Discord servers** with active communities — join them and become a genuine participant before launch.
+
+### Pitch & Copy
+
+- [ ] **Draft the OG link preview copy** — title line (includes Person A's name), description line (communicates the product in one sentence), and brief for the preview image.
+- [ ] **Write the one-paragraph press pitch** for the women's safety angle — "The date planning app that filters for first-date safety." This should be ready to send the week the MVP launches.
+- [ ] **Write 3 variations of the "cold DM to creator" message** — short, authentic, no marketing speak. Offer early access, don't ask for a paid post.
+- [ ] **Draft 5 authentic Reddit comment templates** — responses to common planning-problem complaints that naturally mention Dateflow. These are starting points, not copy-paste scripts.
+
+### Analytics & Metrics
+
+- [ ] **Define the metrics dashboard** — which numbers appear on the B2B pitch deck? Session completion rate, Person B join rate, match rate, time to match, post-match action rate.
+- [ ] **Set up PostHog (or chosen analytics tool)** with event tracking for each step of the session funnel. This must be live before the first real user touches the product.
+
+---
+
+## Launch Week Tasks (MVP Goes Live)
+
+### Day 1–3: Inner Circle
+
+- [ ] Send personal messages to the top 15 people on the network list. Individual texts, not group messages.
+- [ ] Ask each person to try it with a real upcoming date, not a test run.
+- [ ] Collect feedback directly — what confused them, where they dropped off, what they'd change.
+
+### Day 3–7: Expand
+
+- [ ] Send to the remaining 35 people on the network list.
+- [ ] Post authentic comments in the bookmarked Reddit threads (only if the thread is still active and relevant).
+- [ ] DM the top 2 creators on the outreach list with early access.
+- [ ] Join the conversation in the Discord servers — mention Dateflow when someone describes the planning problem.
+
+### Day 7–14: Assess & Adjust
+
+- [ ] Review analytics: How many sessions completed? Where is the drop-off?
+- [ ] If Person B completion rate is below 60%, the landing page needs work — flag to the product team immediately.
+- [ ] If sessions are completing but match rate is below 50%, the venue generation needs tuning — flag to the product team.
+- [ ] Send the press pitch to the 3 researched contacts.
+- [ ] Ask the first batch of users: "Would you use this again next time you have a date?" — the answer to this question is more important than any metric.
+
+---
+
+## Success Criteria for Sprint 1
+
+| Metric | Target |
+|--------|--------|
+| Completed session pairs | 25+ in the first 2 weeks |
+| Person B join rate (opened the link and started) | ≥ 70% |
+| Person B completion rate (finished preferences) | ≥ 60% |
+| Match rate (at least one mutual venue match) | ≥ 55% |
+| Creator outreach sent | ≥ 2 DMs |
+| Press pitch sent | ≥ 1 |
+
+These numbers feed directly into the B2B pitch. Every data point is ammunition for the first meeting with Thursday.

--- a/docs/business/team-tooling.md
+++ b/docs/business/team-tooling.md
@@ -1,0 +1,60 @@
+# Dateflow — Business Team Tooling
+
+## Primary Tool: GitHub Projects (Kanban)
+
+The marketing and business team operates from a GitHub Projects board using the **Kanban** preset.
+
+### Why GitHub Projects
+
+- Issues live in the same repo as the product — no sync needed between tools
+- Non-technical team members interact with a clean drag-and-drop board, never touching code
+- Free, no additional subscriptions
+- Custom fields (Priority, Owner, Due Date) can be added as needed
+- Multiple views (Board, Table, Roadmap) can be added to the same project later
+
+### Board Structure
+
+**Columns:**
+
+| Column | What goes here |
+|--------|---------------|
+| **Backlog** | All tasks not yet scheduled for work |
+| **This Week** | Tasks prioritized for the current week |
+| **In Progress** | Actively being worked on by a team member |
+| **Waiting On** | Blocked — waiting on external response, approval, or dependency |
+| **Done** | Completed tasks (archive periodically to keep the board clean) |
+
+### Labels for Business Issues
+
+Apply these labels to issues in the GitHub repo so they can be filtered on the board:
+
+| Label | Use for |
+|-------|---------|
+| `marketing` | Content, community engagement, press outreach |
+| `sales` | B2B outreach, partnership conversations, pitch materials |
+| `partnerships` | Dating app partner research and relationship building |
+| `content` | Social media posts, creator outreach, press pitches |
+| `analytics` | Metrics setup, dashboard creation, data analysis |
+| `research` | Competitive intelligence, market research, user interviews |
+
+### How the Team Uses It
+
+1. **All business tasks are created as GitHub Issues** with the appropriate label
+2. **The board URL is bookmarked** by every team member — this is their daily workspace
+3. **Weekly standup:** review the board, move cards, identify blockers in "Waiting On"
+4. **Each card should have:** a clear description, an owner (assigned), and a due date if time-sensitive
+
+---
+
+## If GitHub Projects Feels Too Dev-Oriented
+
+If the team pushes back, these are the alternatives in order of recommendation:
+
+| Tool | Best For | Why | Cost |
+|------|----------|-----|------|
+| **Notion** | All-in-one wiki + tasks + docs | Business people already know it. Kanban, calendar, and docs in one place. Embed GitHub issue links to stay connected. | Free for small teams |
+| **Linear** | Fast-moving startup teams | Clean, opinionated, fast. Has GitHub sync so issues mirror between both systems. | Free for small teams |
+| **Trello** | Pure kanban simplicity | Lowest learning curve — productive in 5 minutes. | Free tier is generous |
+| **Asana** | Marketing teams specifically | Built for non-technical project management. Templates for content calendars and campaigns. | Free up to 10 users |
+
+**Rule:** Pick one tool and commit. The worst outcome is half the team using Notion and the other half using GitHub Issues. One source of truth, enforced from day one.

--- a/docs/business/user-acquisition-strategy.md
+++ b/docs/business/user-acquisition-strategy.md
@@ -1,0 +1,146 @@
+# Dateflow — User Acquisition Strategy
+
+## The Goal
+
+**100 completed session pairs with a match rate ≥ 55%** — enough clean data to walk into a B2B meeting with Thursday, The League, or Coffee Meets Bagel and show proof this works.
+
+This is not a growth strategy. This is a proof-of-concept seeding playbook. The tactics are different — scrappy, personal, and targeted rather than scalable.
+
+---
+
+## Tier 1: Personal Network (Weeks 1–3 Post-Launch)
+
+**Target: 30–40 completed sessions**
+
+This is unglamorous but it's where the first sessions come from.
+
+### Actions
+
+- [ ] **Direct outreach to friends who are actively dating.** Not a mass blast — individual texts: "Hey, I built this thing. Next time you have a date coming up, try it and tell me what sucked." Give them a reason to care (you're their friend, they want to help).
+- [ ] **Second-degree referral ask.** Ask each friend to send it to one person they know who's dating. Second-degree network doubles reach without feeling spammy.
+- [ ] **University dating culture.** If near a college campus, this demographic is constantly going on first dates. One person in a sorority or fraternity group chat who tries it and shares it can generate 10+ sessions.
+- [ ] **Build a target list of 50 people** in your network who are actively dating — names, how to reach them, best time to ask.
+
+### Why This Works
+
+People try tools their friends ask them to try. The conversion rate on a personal ask from a friend is 10–50x higher than any ad or cold post. At this stage, every session matters individually — treat each one like a sales conversation.
+
+---
+
+## Tier 2: Targeted Community Presence (Weeks 2–6)
+
+**Target: 30–40 completed sessions**
+
+Go where people are already complaining about the planning problem.
+
+### Reddit
+
+- **Target subreddits:** r/hingeapp, r/Tinder, r/dating_advice, r/datingoverthirty, r/bumble
+- **Do not post "check out my app."** Find threads where people are literally describing the planning failure — "we matched 3 weeks ago and still haven't met up," "I asked her out and she said yes but we can't figure out what to do."
+- **Reply authentically.** "I actually built something for exactly this" with a link. One well-placed comment on a viral thread can drive 20+ signups.
+- [ ] **Identify 10 Reddit threads from the last 30 days** where the planning problem is described — bookmark them for post-launch commenting.
+
+### Discord
+
+- Dating-focused Discord servers exist and are active. Search Disboard for dating/relationship servers.
+- Same approach: be a member first, offer the tool when it's genuinely relevant to a conversation.
+
+### Twitter / X
+
+- Dating hot takes go viral constantly. Quote-tweet or reply to "the worst part of dating apps is..." moments with the product when genuinely relevant.
+- The structural misalignment argument ("dating apps won't build this because faster dates = faster churn") is the kind of thread that gets engagement from tech/startup Twitter.
+
+### Rules of Engagement
+
+1. **Never spam.** One bad-faith post in a subreddit gets you banned and burns the channel permanently.
+2. **Contribute before you promote.** Answer questions, share genuine advice, be a member of the community for at least a few days before mentioning your product.
+3. **Only mention Dateflow when it's a direct answer to someone's stated problem.** If the comment doesn't describe the planning problem, don't shoehorn it in.
+
+---
+
+## Tier 3: One Piece of Earned Media (Weeks 3–8)
+
+**Target: 20–30 completed sessions from a single content hit**
+
+You don't need a PR strategy. You need one piece of content that reaches the right audience.
+
+### The Women's Safety Press Angle
+
+This is the strongest press hook Dateflow has. "The date planning app that filters for first-date safety" is a story that writes itself for:
+
+- **Women's lifestyle press:** Refinery29, The Cut, Bustle, Cosmopolitan
+- **Dating vertical press:** Global Dating Insights
+- **Tech press (secondary):** TechCrunch, The Verge (if framed as a counter-narrative to dating app complacency)
+
+The pitch: Dating apps optimize for the match and abandon users at the planning stage. Women meeting strangers from apps have real safety concerns — public venues, independent accessibility, easy exits — and no tool addresses them. Dateflow makes "first-date safe" a default filter.
+
+- [ ] **Research 3 press contacts** at dating/women's lifestyle outlets who cover dating app stories.
+- [ ] **Write the one-paragraph pitch** for the women's safety angle.
+
+### One Creator Video
+
+- Find a dating content creator on TikTok or Instagram Reels (50K–200K follower range — mid-tier has better engagement and is more likely to respond to a DM).
+- Look for creators who have previously posted about first date planning struggles, the "where should we go" loop, or dating app frustrations.
+- DM them, give them early access, let them make their own content. Don't script it — authentic reaction content performs better.
+- One genuine creator video to a targeted audience can generate 30–50+ sessions.
+
+- [ ] **Find 5 dating content creators** (TikTok/Reels, 50K–200K followers) who have posted about first date planning — compile a DM outreach list.
+
+### Secondary Press Angle
+
+"The company building the feature dating apps won't" — the structural misalignment argument. Dating apps make money from subscriptions; users who find a partner quickly churn. This creates a perverse incentive to not invest in the planning layer. Dateflow builds what they structurally can't. This is a narrative tech journalists know how to write.
+
+---
+
+## Tier 4: The Product as Marketing
+
+Every session Person A creates is a marketing impression on Person B. If Person B's experience is exceptional, they become Person A next time. This is the organic flywheel that compounds — but only if the first impression is flawless.
+
+### The OG Link Preview
+
+When Person A pastes the Dateflow link into iMessage or WhatsApp, the rich preview is Person B's first impression of the product. A bare URL looks like a phishing link from a near-stranger. A well-crafted preview looks like a real product.
+
+- [ ] **Draft the OG link preview copy** — title, description, and preview image that appears in messaging apps.
+- The preview must communicate: what this is, who sent it, that it's fast, that no account is needed.
+
+### The 3-Second Landing Page
+
+Person B clicks the link. If they can't understand what the page is, why it's trustworthy, and what to do — in 3 seconds — they leave. This page has higher leverage than any other screen in the product.
+
+- The landing screen answers three questions: What is this? Why should I trust it? What do I do right now?
+- One button. Not a form. Not a feature list. One button.
+
+### The Match Reveal Moment
+
+The match reveal is the product's peak emotional moment — equivalent to Tinder's "It's a Match!" but for a concrete plan. Make it screenshot-worthy and shareable. This is the "tell your friends" moment.
+
+---
+
+## What NOT to Spend Time or Money on Yet
+
+| Activity | Why Not Now |
+|----------|-----------|
+| Paid ads (Google, Meta, TikTok) | No product-market fit data to optimize against. You'd be burning money to learn what organic testing teaches for free. |
+| Polished marketing website | A simple landing page with the value prop is enough. Nobody is evaluating your website design at this stage. |
+| Brand guidelines / logo redesign / visual identity | Premature. The product will change. The brand can be refined later. |
+| Broad social media presence | Nobody follows a startup's Instagram pre-launch. Don't maintain accounts that have no audience. |
+| Content marketing / blog posts | Wrong stage, wrong audience. Your users are on dating apps and Reddit, not reading startup blogs. |
+| SEO optimization | The payoff timeline for SEO is 6–12 months. You need sessions in 6–12 weeks. |
+
+---
+
+## Analytics From Day One
+
+The consumer demo exists to generate proof for B2B pitches. Every session should emit metrics that map directly to the pitch deck:
+
+- [ ] **Set up PostHog (or equivalent)** to track session funnels and drop-off per step.
+- **Key metrics to capture:**
+  - Session creation rate (Person A starts a session)
+  - Invite send rate (Person A shares the link)
+  - Person B join rate (Person B opens the link)
+  - Person B completion rate (Person B finishes preferences)
+  - Match rate (at least one mutual venue match per session)
+  - Time to match (how long from session creation to match reveal)
+  - Post-match action rate (directions opened, calendar event created — proxy for "date actually happened")
+
+The single metric that closes B2B deals: **"Apps using Dateflow show X% higher match-to-date conversion rate."** Design analytics to capture this from session one.


### PR DESCRIPTION
## Summary
- Creates `docs/business/` as the home for business team documentation
- Adds **user acquisition strategy** — tiered playbook (network → communities → earned media → product-as-marketing) targeting 100 completed session pairs for B2B proof
- Adds **team tooling guide** — GitHub Projects kanban setup with board structure, labels (`biz`/`dev`), and fallback alternatives
- Adds **first sprint checklist** — pre-launch research tasks and launch week execution plan with success criteria
- Updates README to reference the new business docs folder

## Test plan
- [ ] Verify all three new docs render correctly on GitHub
- [ ] Verify README links to `docs/business/` resolve properly
- [ ] Review content against existing planning docs for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)