### PR TITLE
feat: DS-01 session types and database schema

### DIFF
--- a/web-service/src/lib/types/__tests__/session.test.ts
+++ b/web-service/src/lib/types/__tests__/session.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { toSession } from "../session";
+import type { SessionRow } from "../session";
+
+describe("toSession", () => {
+  const baseRow: SessionRow = {
+    id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    status: "pending_b",
+    creator_display_name: "Alex",
+    created_at: "2026-03-27T12:00:00Z",
+    expires_at: "2026-03-29T12:00:00Z",
+    matched_venue_id: null,
+  };
+
+  it("maps snake_case row fields to camelCase Session fields", () => {
+    const session = toSession(baseRow);
+
+    expect(session.id).toBe(baseRow.id);
+    expect(session.status).toBe(baseRow.status);
+    expect(session.creatorDisplayName).toBe(baseRow.creator_display_name);
+    expect(session.matchedVenueId).toBe(baseRow.matched_venue_id);
+  });
+
+  it("converts ISO date strings to Date objects", () => {
+    const session = toSession(baseRow);
+
+    expect(session.createdAt).toBeInstanceOf(Date);
+    expect(session.expiresAt).toBeInstanceOf(Date);
+    expect(session.createdAt.toISOString()).toBe("2026-03-27T12:00:00.000Z");
+    expect(session.expiresAt.toISOString()).toBe("2026-03-29T12:00:00.000Z");
+  });
+
+  it("preserves null matchedVenueId", () => {
+    const session = toSession(baseRow);
+
+    expect(session.matchedVenueId).toBeNull();
+  });
+
+  it("passes through a non-null matchedVenueId", () => {
+    const rowWithVenue: SessionRow = {
+      ...baseRow,
+      matched_venue_id: "venue-abc-123",
+    };
+    const session = toSession(rowWithVenue);
+
+    expect(session.matchedVenueId).toBe("venue-abc-123");
+  });
+});

--- a/web-service/src/lib/types/session.ts
+++ b/web-service/src/lib/types/session.ts
@@ -1,0 +1,78 @@
+/**
+ * The 7 states a session moves through during its lifecycle.
+ *
+ * DS-01 introduces:  pending_b, expired
+ * DS-02 adds:        both_ready
+ * DS-03 adds:        generating, generation_failed
+ * DS-04 adds:        ready_to_swipe, matched
+ */
+export type SessionStatus =
+  | "pending_b"
+  | "both_ready"
+  | "generating"
+  | "generation_failed"
+  | "ready_to_swipe"
+  | "matched"
+  | "expired";
+
+/**
+ * A planning session between two people.
+ *
+ * Created when Person A starts the flow (/plan page).
+ * Persists until matched (both swiped right) or expired (48h timeout).
+ */
+export type Session = {
+  readonly id: string;
+  readonly status: SessionStatus;
+  readonly creatorDisplayName: string;
+  readonly createdAt: Date;
+  readonly expiresAt: Date;
+  readonly matchedVenueId: string | null;
+};
+
+/**
+ * The shareable invite URL for a session.
+ *
+ * Generated after session creation so Person A can send it to Person B.
+ * The URL points to /plan/[sessionId] where Person B enters preferences.
+ */
+export type ShareLink = {
+  readonly sessionId: string;
+  readonly url: string;
+  readonly expiresAt: Date;
+};
+
+// ---------------------------------------------------------------------------
+// Database layer — maps Supabase/Postgres snake_case rows to app-level types
+// ---------------------------------------------------------------------------
+
+/**
+ * The raw row shape returned by Supabase when querying the sessions table.
+ * Column names are snake_case (Postgres convention).
+ * Dates come back as ISO 8601 strings over the wire.
+ */
+export type SessionRow = {
+  readonly id: string;
+  readonly status: SessionStatus;
+  readonly creator_display_name: string;
+  readonly created_at: string;
+  readonly expires_at: string;
+  readonly matched_venue_id: string | null;
+};
+
+/**
+ * Converts a raw Supabase row into an app-level Session.
+ *
+ * This is the single conversion point — every DB query result passes through
+ * here exactly once, so field mapping and date parsing happen in one place.
+ */
+export function toSession(row: SessionRow): Session {
+  return {
+    id: row.id,
+    status: row.status,
+    creatorDisplayName: row.creator_display_name,
+    createdAt: new Date(row.created_at),
+    expiresAt: new Date(row.expires_at),
+    matchedVenueId: row.matched_venue_id,
+  };
+}

--- a/web-service/supabase/migrations/001_create_sessions.sql
+++ b/web-service/supabase/migrations/001_create_sessions.sql
@@ -1,0 +1,33 @@
+-- 001_create_sessions.sql
+-- DS-01: Session Management — creates the core sessions table.
+--
+-- This is the first table in the system. Every other feature (preferences,
+-- venue generation, swiping) hangs off a session ID.
+
+CREATE TABLE sessions (
+  id                   uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  status               text        NOT NULL DEFAULT 'pending_b'
+                                   CHECK (status IN (
+                                     'pending_b',
+                                     'both_ready',
+                                     'generating',
+                                     'generation_failed',
+                                     'ready_to_swipe',
+                                     'matched',
+                                     'expired'
+                                   )),
+  creator_display_name text        NOT NULL,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  expires_at           timestamptz NOT NULL DEFAULT now() + interval '48 hours',
+  matched_venue_id     text
+);
+
+-- Partial index: only indexes sessions that are still "in play" (not matched
+-- or expired). This keeps the index small and fast — finished sessions are
+-- the majority over time but are never queried by the active-session paths.
+--
+-- Used by: SessionService.expireStaleSessions() to find sessions past their
+-- expiry, and validateSessionForJoin() to check if a session is joinable.
+CREATE INDEX idx_sessions_status_expires
+  ON sessions (status, expires_at)
+  WHERE status NOT IN ('matched', 'expired');


### PR DESCRIPTION
## Summary
- Define `SessionStatus`, `Session`, and `ShareLink` TypeScript types as the data contracts for DS-01 session management
- Add `SessionRow` type + `toSession()` mapper to convert Supabase snake_case rows to camelCase app types with proper Date parsing
- Add SQL migration for `sessions` table with CHECK constraint on status (7 valid values) and partial index on active sessions

## Test plan
- [x] 4 unit tests for `toSession()` mapper (field mapping, date conversion, null/non-null matchedVenueId)
- [x] All 8 existing tests pass (4 supabase + 4 session)
- [x] Lint, test, build all pass
- [x] Run `001_create_sessions.sql` in Supabase SQL Editor to create the table

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)