### PR TITLE
feat: DS-02 preference types, enums, and database schema

### DIFF
--- a/web-service/src/lib/services/preference-serializer.ts
+++ b/web-service/src/lib/services/preference-serializer.ts
@@ -1,0 +1,37 @@
+import type {
+  Preference,
+  Role,
+  Location,
+  BudgetLevel,
+  Category,
+} from "../types/preference";
+
+/**
+ * JSON-safe version of Preference — createdAt becomes an ISO string.
+ * This is the shape the API returns and the frontend receives.
+ */
+export type SerializedPreference = {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly role: Role;
+  readonly location: Location;
+  readonly budget: BudgetLevel;
+  readonly categories: readonly Category[];
+  readonly createdAt: string;
+};
+
+/**
+ * Converts a Preference (with Date) into a JSON-safe format (with ISO string).
+ * Call this before returning a preference from an API route.
+ */
+export function serializePreference(pref: Preference): SerializedPreference {
+  return {
+    id: pref.id,
+    sessionId: pref.sessionId,
+    role: pref.role,
+    location: pref.location,
+    budget: pref.budget,
+    categories: pref.categories,
+    createdAt: pref.createdAt.toISOString(),
+  };
+}

--- a/web-service/src/lib/types/__tests__/preference.test.ts
+++ b/web-service/src/lib/types/__tests__/preference.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { toPreference, serializePreference } from "../preference";
+import { toPreference } from "../preference";
+import { serializePreference } from "../../services/preference-serializer";
 import type { PreferenceRow } from "../preference";
 import type { Preference } from "../preference";
 

--- a/web-service/src/lib/types/preference.ts
+++ b/web-service/src/lib/types/preference.ts
@@ -88,34 +88,3 @@ export function toPreference(row: PreferenceRow): Preference {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Serialization — for API responses
-// ---------------------------------------------------------------------------
-
-/**
- * JSON-safe version of Preference — createdAt becomes an ISO string.
- */
-export type SerializedPreference = {
-  readonly id: string;
-  readonly sessionId: string;
-  readonly role: Role;
-  readonly location: Location;
-  readonly budget: BudgetLevel;
-  readonly categories: readonly Category[];
-  readonly createdAt: string;
-};
-
-/**
- * Converts a Preference (with Date) into a JSON-safe format (with ISO string).
- */
-export function serializePreference(pref: Preference): SerializedPreference {
-  return {
-    id: pref.id,
-    sessionId: pref.sessionId,
-    role: pref.role,
-    location: pref.location,
-    budget: pref.budget,
-    categories: pref.categories,
-    createdAt: pref.createdAt.toISOString(),
-  };
-}

--- a/web-service/supabase/migrations/002_create_preferences.sql
+++ b/web-service/supabase/migrations/002_create_preferences.sql
@@ -10,7 +10,7 @@ CREATE TABLE preferences (
   role        text        NOT NULL CHECK (role IN ('a', 'b')),
   location    jsonb       NOT NULL,
   budget      text        NOT NULL CHECK (budget IN ('BUDGET', 'MODERATE', 'UPSCALE')),
-  categories  text[]      NOT NULL CHECK (array_length(categories, 1) > 0),
+  categories  text[]      NOT NULL CHECK (cardinality(categories) > 0),
   created_at  timestamptz NOT NULL DEFAULT now(),
 
   -- One preference per person per session. If Person A already submitted,
@@ -19,6 +19,6 @@ CREATE TABLE preferences (
   UNIQUE (session_id, role)
 );
 
--- Enable RLS — same pattern as sessions. The service role key bypasses
--- this, so API routes work fine. Direct anon access is blocked.
+-- Enable RLS on preferences. The service role key bypasses this, so
+-- API routes work fine while direct anon access is blocked.
 ALTER TABLE preferences ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- Add preference domain types (`Role`, `BudgetLevel`, `Category`, `Location`, `Preference`, `PreferenceInput`) with full immutability
- Add `PreferenceRow` → `Preference` row mapper and `SerializedPreference` serializer (same three-shape pattern as sessions)
- Add `002_create_preferences.sql` migration with `UNIQUE(session_id, role)`, `ON DELETE CASCADE`, JSONB location, text[] categories, and RLS enabled
- 6 unit tests for `toPreference` and `serializePreference`

Closes #10

## Test plan
- [x] All 58 tests pass (`bunx vitest run`)
- [x] Lint passes (`bun run lint`)
- [x] Build passes (`bun run build`)
- [ ] Run `002_create_preferences.sql` in Supabase SQL Editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)