### PR TITLE
feat: DS-02 PreferenceService and preference API route

### DIFF
--- a/web-service/src/app/api/sessions/[id]/preferences/__tests__/route.test.ts
+++ b/web-service/src/app/api/sessions/[id]/preferences/__tests__/route.test.ts
@@ -284,6 +284,18 @@ describe("POST /api/sessions/[id]/preferences", () => {
     expect(response.status).toBe(410);
   });
 
+  // --- Status check ---
+
+  it("returns 409 when session is not in pending_b status", async () => {
+    mockGetSession.mockResolvedValue({ ...fakeSession, status: "both_ready" });
+
+    const response = await POST(makePostRequest(validBody), makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("not accepting preferences");
+  });
+
   // --- Duplicate check ---
 
   it("returns 409 when preference already exists for that role", async () => {
@@ -296,6 +308,20 @@ describe("POST /api/sessions/[id]/preferences", () => {
 
     expect(response.status).toBe(409);
     expect(body.error).toBeDefined();
+  });
+
+  // --- Race condition: DB unique constraint → 409 ---
+
+  it("returns 409 when DB throws unique constraint violation", async () => {
+    mockSubmitPreference.mockRejectedValue(
+      new Error("duplicate key value violates unique constraint")
+    );
+
+    const response = await POST(makePostRequest(validBody), makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("already submitted");
   });
 
   // --- Unexpected errors ---

--- a/web-service/src/app/api/sessions/[id]/preferences/route.ts
+++ b/web-service/src/app/api/sessions/[id]/preferences/route.ts
@@ -147,7 +147,15 @@ export async function POST(request: Request, { params }: RouteParams) {
       );
     }
 
-    // 5. Check for duplicate preference
+    // 5. Check session is accepting preferences
+    if (session.status !== "pending_b") {
+      return NextResponse.json(
+        { error: "This session is not accepting preferences" },
+        { status: 409 }
+      );
+    }
+
+    // 6. Check for duplicate preference
     const existing = await getPreferences(id);
     const alreadySubmitted = existing.some((p) => p.role === role);
 
@@ -158,7 +166,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       );
     }
 
-    // 6. Submit preference (and trigger transition if both ready)
+    // 7. Submit preference (and trigger transition if both ready)
     const preference = await submitPreference(id, {
       role,
       location,
@@ -171,6 +179,16 @@ export async function POST(request: Request, { params }: RouteParams) {
       { status: 201 }
     );
   } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    const isUniqueViolation = message.includes("unique") || message.includes("duplicate");
+
+    if (isUniqueViolation) {
+      return NextResponse.json(
+        { error: "Preference already submitted for this role" },
+        { status: 409 }
+      );
+    }
+
     console.error(`[POST /api/sessions/${id}/preferences] Failed:`, err);
     return NextResponse.json(
       { error: "Something went wrong. Please try again." },

--- a/web-service/src/lib/services/__tests__/preference-service.test.ts
+++ b/web-service/src/lib/services/__tests__/preference-service.test.ts
@@ -27,9 +27,11 @@ const mockInsert = vi.fn(() => ({ select: mockInsertSelect }));
 const mockSelectEq = vi.fn();
 const mockQuerySelect = vi.fn(() => ({ eq: mockSelectEq }));
 
-// UPDATE chain: from("sessions").update().eq()
-const mockUpdateEq = vi.fn();
-const mockUpdate = vi.fn(() => ({ eq: mockUpdateEq }));
+// UPDATE chain: from("sessions").update().eq("id", ...).eq("status", ...)
+// Second .eq() is the terminal call that returns { data, error }
+const mockUpdateStatusEq = vi.fn();
+const mockUpdateIdEq = vi.fn(() => ({ eq: mockUpdateStatusEq }));
+const mockUpdate = vi.fn(() => ({ eq: mockUpdateIdEq }));
 
 // from() routes to the right chain based on table name
 const mockFrom = vi.fn((table: string) => {
@@ -130,7 +132,7 @@ describe("submitPreference", () => {
     // Person B submits — now both rows exist
     mockInsertSingle.mockResolvedValue({ data: fakeRowB, error: null });
     mockSelectEq.mockResolvedValue({ data: [fakeRow, fakeRowB], error: null });
-    mockUpdateEq.mockResolvedValue({ data: null, error: null });
+    mockUpdateStatusEq.mockResolvedValue({ data: null, error: null });
 
     await submitPreference("session-uuid-5678", {
       ...fakeInput,
@@ -141,10 +143,11 @@ describe("submitPreference", () => {
     expect(mockFrom).toHaveBeenCalledWith("preferences");
     expect(mockSelectEq).toHaveBeenCalledWith("session_id", "session-uuid-5678");
 
-    // Verify it updated the session status
+    // Verify it updated the session status — only from pending_b
     expect(mockFrom).toHaveBeenCalledWith("sessions");
     expect(mockUpdate).toHaveBeenCalledWith({ status: "both_ready" });
-    expect(mockUpdateEq).toHaveBeenCalledWith("id", "session-uuid-5678");
+    expect(mockUpdateIdEq).toHaveBeenCalledWith("id", "session-uuid-5678");
+    expect(mockUpdateStatusEq).toHaveBeenCalledWith("status", "pending_b");
   });
 
   it("does NOT transition when only one preference exists", async () => {
@@ -161,7 +164,7 @@ describe("submitPreference", () => {
   it("returns the preference even when transition happens", async () => {
     mockInsertSingle.mockResolvedValue({ data: fakeRowB, error: null });
     mockSelectEq.mockResolvedValue({ data: [fakeRow, fakeRowB], error: null });
-    mockUpdateEq.mockResolvedValue({ data: null, error: null });
+    mockUpdateStatusEq.mockResolvedValue({ data: null, error: null });
 
     const result = await submitPreference("session-uuid-5678", {
       ...fakeInput,

--- a/web-service/src/lib/services/preference-service.ts
+++ b/web-service/src/lib/services/preference-service.ts
@@ -42,11 +42,12 @@ export async function submitPreference(
   const allPrefs = await getPreferences(sessionId);
 
   if (allPrefs.length >= 2) {
-    // 3. Transition session to both_ready
+    // 3. Transition session to both_ready — only from pending_b
     const { error: updateError } = await supabase
       .from("sessions")
       .update({ status: "both_ready" })
-      .eq("id", sessionId);
+      .eq("id", sessionId)
+      .eq("status", "pending_b");
 
     if (updateError) {
       throw new Error(updateError.message);
@@ -88,9 +89,12 @@ export async function getBothPreferences(
 ): Promise<[Preference, Preference]> {
   const preferences = await getPreferences(sessionId);
 
-  if (preferences.length < 2) {
+  const prefA = preferences.find((p) => p.role === "a");
+  const prefB = preferences.find((p) => p.role === "b");
+
+  if (!prefA || !prefB) {
     throw new Error("Both preferences are required");
   }
 
-  return [preferences[0], preferences[1]];
+  return [prefA, prefB];
 }


### PR DESCRIPTION
## Summary

- **PreferenceService** with `submitPreference`, `getPreferences`, and `getBothPreferences` — handles insert, flexible read, and strict two-preference read for DS-03
- **Session status transition** — automatically transitions `pending_b → both_ready` when the second preference arrives
- **`POST /api/sessions/[id]/preferences`** route with full input validation: lat/lng ranges, budget enum, 1-4 valid categories, role check, session existence (404), expiry (410), and duplicate prevention (409)
- **31 tests** — 11 for service logic, 20 for the route covering every validation rule and HTTP status code

Closes #11

## Test plan

- [x] `bunx vitest run` — all 89 tests pass
- [x] `bun run lint` — 0 errors
- [x] `bun run build` — compiles, new route visible in build output
- [ ] Verify 201 for valid preference submission
- [ ] Verify 400 for each invalid field (role, lat/lng, budget, categories)
- [ ] Verify 404 for nonexistent session, 410 for expired, 409 for duplicate role

🤖 Generated with [Claude Code](https://claude.com/claude-code)