### PR TITLE
fix: enable RLS on venues table

### DIFF
--- a/web-service/supabase/migrations/003_create_venues.sql
+++ b/web-service/supabase/migrations/003_create_venues.sql
@@ -51,3 +51,8 @@ CREATE INDEX idx_venues_composite_score
        + score_quality_signal + score_time_of_day_fit) / 5
     ) DESC
   );
+
+-- Enable RLS on venues. The service role key (used by API routes) bypasses this,
+-- so direct client access is protected. Policies would be added in a future migration
+-- once the auth model is finalized.
+ALTER TABLE venues ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
Added `ALTER TABLE venues ENABLE ROW LEVEL SECURITY;` to the venues migration to match the security posture of the preferences table.

## Details
- Service role key (used by API routes) bypasses RLS, so this doesn't affect current functionality
- When auth/authorization is added in DS-06, RLS policies can be defined to restrict direct client access
- Migrations are idempotent via Supabase's version control

## Testing
- Drop existing `venues` table manually in Supabase (if running locally)
- Re-run migration 003
- Verify RLS is enabled: `SELECT relrowsecurity FROM pg_class WHERE relname = 'venues';` should return true

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)