### PR TITLE
feat: add DS-04 swipe and status routes

### DIFF
--- a/web-service/src/app/api/sessions/[id]/status/__tests__/route.test.ts
+++ b/web-service/src/app/api/sessions/[id]/status/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetSession = vi.fn();
 const mockGetCurrentRound = vi.fn();
@@ -34,8 +34,14 @@ const readySession = {
 };
 
 describe("GET /api/sessions/[id]/status", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-03T12:00:00Z"));
     mockGetSession.mockResolvedValue(readySession);
     mockGetCurrentRound.mockResolvedValue(2);
     mockGetRoundCompletion.mockResolvedValue({
@@ -94,8 +100,47 @@ describe("GET /api/sessions/[id]/status", () => {
     expect(body).toEqual({
       status: "matched",
       matchedVenueId: "venue-12",
-      currentRound: undefined,
-      roundComplete: undefined,
+    });
+  });
+
+  it("returns active non-swipeable states without round progress", async () => {
+    mockGetSession.mockResolvedValue({
+      ...readySession,
+      status: "generating",
+    });
+
+    const response = await GET(makeGetRequest(), {
+      params: Promise.resolve({ id: "session-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetCurrentRound).not.toHaveBeenCalled();
+    expect(mockGetRoundCompletion).not.toHaveBeenCalled();
+    expect(body).toEqual({
+      status: "generating",
+      matchedVenueId: null,
+    });
+  });
+
+  it("returns expired status when the session has passed expiresAt even if DB status has not flipped yet", async () => {
+    mockGetSession.mockResolvedValue({
+      ...readySession,
+      expiresAt: new Date("2026-04-02T12:00:00Z"),
+      status: "ready_to_swipe",
+    });
+
+    const response = await GET(makeGetRequest(), {
+      params: Promise.resolve({ id: "session-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetCurrentRound).not.toHaveBeenCalled();
+    expect(mockGetRoundCompletion).not.toHaveBeenCalled();
+    expect(body).toEqual({
+      status: "expired",
+      matchedVenueId: null,
     });
   });
 });

--- a/web-service/src/app/api/sessions/[id]/status/route.ts
+++ b/web-service/src/app/api/sessions/[id]/status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getSession } from "../../../../../lib/services/session-service";
 import { getCurrentRound } from "../../../../../lib/services/round-manager";
 import { getRoundCompletion } from "../../../../../lib/services/swipe-service";
+import { isExpired } from "../../../../../lib/services/session-helpers";
 
 type RouteParams = {
   params: Promise<{ id: string }>;
@@ -20,18 +21,26 @@ export async function GET(_request: Request, { params }: RouteParams) {
       );
     }
 
+    if (session.status === "expired" || isExpired(session)) {
+      return NextResponse.json({
+        status: "expired",
+        matchedVenueId: session.matchedVenueId,
+      });
+    }
+
     if (
       session.status === "matched" ||
-      session.status === "expired" ||
       session.status === "fallback_pending" ||
       session.status === "retry_pending" ||
-      session.status === "reranking"
+      session.status === "reranking" ||
+      session.status === "pending_b" ||
+      session.status === "both_ready" ||
+      session.status === "generating" ||
+      session.status === "generation_failed"
     ) {
       return NextResponse.json({
         status: session.status,
         matchedVenueId: session.matchedVenueId,
-        currentRound: undefined,
-        roundComplete: undefined,
       });
     }
 

--- a/web-service/src/app/api/sessions/[id]/swipes/__tests__/route.test.ts
+++ b/web-service/src/app/api/sessions/[id]/swipes/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetSession = vi.fn();
 const mockRecordSwipe = vi.fn();
@@ -31,8 +31,14 @@ const readySession = {
 };
 
 describe("POST /api/sessions/[id]/swipes", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-03T12:00:00Z"));
     mockGetSession.mockResolvedValue(readySession);
     mockRecordSwipe.mockResolvedValue({
       matched: false,
@@ -118,5 +124,62 @@ describe("POST /api/sessions/[id]/swipes", () => {
     expect(response.status).toBe(409);
     expect(body.error).toContain("not accepting swipes");
     expect(mockRecordSwipe).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the session is awaiting a fallback decision", async () => {
+    mockGetSession.mockResolvedValue({
+      ...readySession,
+      status: "fallback_pending",
+      matchedVenueId: "venue-12",
+    });
+
+    const response = await POST(makePostRequest({
+      venueId: "venue-1",
+      role: "a",
+      liked: true,
+    }), {
+      params: Promise.resolve({ id: "session-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("fallback decision");
+    expect(mockRecordSwipe).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when recordSwipe reports a bad venue or current round error", async () => {
+    mockRecordSwipe.mockRejectedValue(
+      new Error("Venue venue-9 is not in the current round"),
+    );
+
+    const response = await POST(makePostRequest({
+      venueId: "venue-9",
+      role: "a",
+      liked: true,
+    }), {
+      params: Promise.resolve({ id: "session-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("current round");
+  });
+
+  it("returns 409 when recordSwipe reports an invalid session state", async () => {
+    mockRecordSwipe.mockRejectedValue(
+      new Error("cannot swipe when session status is generating"),
+    );
+
+    const response = await POST(makePostRequest({
+      venueId: "venue-1",
+      role: "a",
+      liked: true,
+    }), {
+      params: Promise.resolve({ id: "session-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("session status");
   });
 });

--- a/web-service/src/app/api/sessions/[id]/swipes/route.ts
+++ b/web-service/src/app/api/sessions/[id]/swipes/route.ts
@@ -93,10 +93,17 @@ export async function POST(request: Request, { params }: RouteParams) {
       );
     }
 
-    if (
-      session.status !== "ready_to_swipe" &&
-      session.status !== "fallback_pending"
-    ) {
+    if (session.status === "fallback_pending") {
+      return NextResponse.json(
+        {
+          error:
+            "This session is awaiting a fallback decision and is not accepting swipes",
+        },
+        { status: 409 },
+      );
+    }
+
+    if (session.status !== "ready_to_swipe") {
       return NextResponse.json(
         { error: "This session is not accepting swipes" },
         { status: 409 },
@@ -112,6 +119,22 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     return NextResponse.json(result, { status: 200 });
   } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+
+    if (message.includes("current round") || message.includes("Venue ")) {
+      return NextResponse.json(
+        { error: message },
+        { status: 400 },
+      );
+    }
+
+    if (message.includes("session status")) {
+      return NextResponse.json(
+        { error: message },
+        { status: 409 },
+      );
+    }
+
     console.error(`[POST /api/sessions/${id}/swipes] Failed:`, err);
     return NextResponse.json(
       { error: "Something went wrong. Please try again." },


### PR DESCRIPTION
## Summary
- add `POST /api/sessions/[id]/swipes` with body validation, session state checks, and delegation to `recordSwipe`
- add `GET /api/sessions/[id]/status` for polling current session state and round progress
- cover both routes with focused API tests

## Test plan
- [x] `~/.codex/bin/tdd-lock verify`
- [x] `bun run test -- 'src/app/api/sessions/[id]/swipes/__tests__/route.test.ts' 'src/app/api/sessions/[id]/status/__tests__/route.test.ts'`
- [x] `bun run lint 'src/app/api/sessions/[id]/swipes/route.ts' 'src/app/api/sessions/[id]/swipes/__tests__/route.test.ts' 'src/app/api/sessions/[id]/status/route.ts' 'src/app/api/sessions/[id]/status/__tests__/route.test.ts'`
- [x] `bun run build`