### PR TITLE
Add DS-05 directions service

### DIFF
--- a/web-service/src/lib/services/__tests__/directions-service.test.ts
+++ b/web-service/src/lib/services/__tests__/directions-service.test.ts
@@ -47,6 +47,14 @@ describe("directions-service", () => {
     expect(platform).toBe("android");
   });
 
+  it("detects ipad os desktop-style user agents as ios", () => {
+    const platform = detectPlatform(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+    );
+
+    expect(platform).toBe("ios");
+  });
+
   it("defaults to desktop for non-mobile user agents", () => {
     const platform = detectPlatform(
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"

--- a/web-service/src/lib/services/directions-service.ts
+++ b/web-service/src/lib/services/directions-service.ts
@@ -7,6 +7,10 @@ export function detectPlatform(userAgent: string): Platform {
     return "ios";
   }
 
+  if (/Macintosh/i.test(userAgent) && /Mobile/i.test(userAgent)) {
+    return "ios";
+  }
+
   if (/Android/i.test(userAgent)) {
     return "android";
   }


### PR DESCRIPTION
## Summary
- add a dedicated directions service for platform detection and deep-link generation
- cover iOS, Android, and desktop directions behavior with focused tests
- keep the DS-05 directions logic isolated from the page layer

## Test plan
- [x] `~/.codex/bin/tdd-lock verify`
- [x] `bun run test -- src/lib/services/__tests__/directions-service.test.ts src/lib/services/__tests__/result-service.test.ts src/lib/services/__tests__/result-serializer.test.ts 'src/app/api/sessions/[id]/result/__tests__/route.test.ts'`
- [x] `bun run lint src/lib/services/directions-service.ts src/lib/services/result-service.ts src/lib/services/result-serializer.ts src/lib/types/match-result.ts src/lib/services/__tests__/directions-service.test.ts src/lib/services/__tests__/result-service.test.ts src/lib/services/__tests__/result-serializer.test.ts 'src/app/api/sessions/[id]/result/route.ts' 'src/app/api/sessions/[id]/result/__tests__/route.test.ts'`
- [x] `bun run build`