### PR TITLE
Add DS-05 calendar export service and API

### DIFF
--- a/web-service/src/app/api/sessions/[id]/calendar/__tests__/route.test.ts
+++ b/web-service/src/app/api/sessions/[id]/calendar/__tests__/route.test.ts
@@ -105,6 +105,17 @@ describe("GET /api/sessions/[id]/calendar", () => {
     expect(mockGetMatchResult).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for a non-ISO dateTime string that Date would otherwise parse", async () => {
+    const response = await GET(makeRequest("?dateTime=2026-04-05 19:30:00"), {
+      params: Promise.resolve({ id: "session-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("dateTime must be a valid ISO 8601 string");
+    expect(mockGetMatchResult).not.toHaveBeenCalled();
+  });
+
   it("returns 404 when the session does not exist", async () => {
     mockGetMatchResult.mockRejectedValue(new Error("Session not found"));
 

--- a/web-service/src/app/api/sessions/[id]/calendar/route.ts
+++ b/web-service/src/app/api/sessions/[id]/calendar/route.ts
@@ -6,9 +6,16 @@ type RouteParams = {
   params: Promise<{ id: string }>;
 };
 
+const ISO_8601_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
 function parseDateTime(value: string | null): Date | undefined {
   if (value === null) {
     return undefined;
+  }
+
+  if (!ISO_8601_PATTERN.test(value)) {
+    throw new Error("dateTime must be a valid ISO 8601 string");
   }
 
   const date = new Date(value);

--- a/web-service/src/lib/services/__tests__/calendar-export-service.test.ts
+++ b/web-service/src/lib/services/__tests__/calendar-export-service.test.ts
@@ -5,8 +5,6 @@ import type { MatchResult } from "../../types/match-result";
 const matchResult: MatchResult = {
   sessionId: "session-1",
   matchedAt: new Date("2026-04-02T18:30:00Z"),
-  directionsUrl:
-    "https://www.google.com/maps/dir/?api=1&destination=12%20Main%20St",
   venue: {
     id: "venue-12",
     sessionId: "session-1",
@@ -35,20 +33,26 @@ const matchResult: MatchResult = {
 
 describe("calendar-export-service", () => {
   it("generates ICS content for an explicit date and time", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+
     const ics = generateICS(matchResult, new Date("2026-04-05T19:30:00Z"));
 
     expect(ics).toContain("BEGIN:VCALENDAR");
     expect(ics).toContain("BEGIN:VEVENT");
+    expect(ics).toContain("UID:session-1@dateflow.app");
+    expect(ics).toContain("DTSTAMP:20260402T183000Z");
     expect(ics).toContain("SUMMARY:Date at Cafe Blue");
     expect(ics).toContain("LOCATION:12 Main St\\, Austin\\, TX");
     expect(ics).toContain(
-      "DESCRIPTION:Planned with Dateflow - https://dateflow.app/plan/session-1/results",
+      "DESCRIPTION:Planned with Dateflow - http://localhost:3000/plan/session-1/results",
     );
     expect(ics).toContain("DTSTART:20260405T193000Z");
     expect(ics).toContain("DTEND:20260405T213000Z");
   });
 
   it("defaults to 7:00 PM the next day when no dateTime is provided", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+
     const ics = generateICS(matchResult);
 
     expect(ics).toContain("DTSTART:20260403T190000Z");

--- a/web-service/src/lib/services/calendar-export-service.ts
+++ b/web-service/src/lib/services/calendar-export-service.ts
@@ -2,6 +2,7 @@ import type { MatchResult } from "../types/match-result";
 
 const DEFAULT_EVENT_HOUR_UTC = 19;
 const EVENT_DURATION_HOURS = 2;
+const DEFAULT_APP_URL = "https://dateflow.app";
 
 function pad(value: number): string {
   return value.toString().padStart(2, "0");
@@ -33,20 +34,27 @@ function escapeICS(value: string): string {
     .replace(/;/g, "\\;");
 }
 
+function getResultsUrl(sessionId: string): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? DEFAULT_APP_URL;
+  return `${appUrl}/plan/${sessionId}/results`;
+}
+
 export function generateICS(
   matchResult: MatchResult,
   dateTime = defaultDateTime(matchResult),
 ): string {
   const endDateTime = new Date(dateTime);
   endDateTime.setUTCHours(endDateTime.getUTCHours() + EVENT_DURATION_HOURS);
-
-  const resultUrl = `https://dateflow.app/plan/${matchResult.sessionId}/results`;
+  const resultUrl = getResultsUrl(matchResult.sessionId);
+  const uid = `${matchResult.sessionId}@dateflow.app`;
 
   return [
     "BEGIN:VCALENDAR",
     "VERSION:2.0",
     "PRODID:-//Dateflow//EN",
     "BEGIN:VEVENT",
+    `UID:${uid}`,
+    `DTSTAMP:${formatICSDate(matchResult.matchedAt)}`,
     `DTSTART:${formatICSDate(dateTime)}`,
     `DTEND:${formatICSDate(endDateTime)}`,
     `SUMMARY:${escapeICS(`Date at ${matchResult.venue.name}`)}`,


### PR DESCRIPTION
## Summary
- add a calendar export service that generates ICS content for matched plans
- add `GET /api/sessions/[id]/calendar` for downloadable calendar responses with optional `dateTime`
- cover ICS content, default scheduling behavior, response headers, and error mapping with focused tests

## Test plan
- [x] `~/.codex/bin/tdd-lock verify`
- [x] `bun run test -- src/lib/services/__tests__/calendar-export-service.test.ts 'src/app/api/sessions/[id]/calendar/__tests__/route.test.ts'`
- [x] `bun run lint src/lib/services/calendar-export-service.ts src/lib/services/__tests__/calendar-export-service.test.ts 'src/app/api/sessions/[id]/calendar/route.ts' 'src/app/api/sessions/[id]/calendar/__tests__/route.test.ts'`
- [x] `bun run build`