### PR TITLE
Support multiple venue photos

### DIFF
--- a/web-service/next.config.ts
+++ b/web-service/next.config.ts
@@ -1,5 +1,21 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+function getAllowedDevOrigins(): string[] {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+  if (!appUrl) {
+    return [];
+  }
+
+  try {
+    return [new URL(appUrl).host];
+  } catch {
+    return [];
+  }
+}
+
+const nextConfig: NextConfig = {
+  allowedDevOrigins: getAllowedDevOrigins(),
+};
 
 export default nextConfig;

--- a/web-service/src/app/api/sessions/[id]/generate/route.ts
+++ b/web-service/src/app/api/sessions/[id]/generate/route.ts
@@ -25,6 +25,10 @@ export async function POST(request: Request, { params }: RouteParams) {
   try {
     const isAuthorized = await verifyQstashRequest(request.clone());
     if (!isAuthorized) {
+      console.warn(`[POST /api/sessions/${id}/generate] QStash authorization failed`, {
+        hasUpstashSignature: Boolean(request.headers.get("Upstash-Signature")),
+        upstashRegion: request.headers.get("Upstash-Region"),
+      });
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/web-service/src/app/api/sessions/[id]/preferences/__tests__/route.test.ts
+++ b/web-service/src/app/api/sessions/[id]/preferences/__tests__/route.test.ts
@@ -12,8 +12,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // without touching a database.
 
 const mockGetSession = vi.fn();
+const mockSetInviteeDisplayName = vi.fn();
 vi.mock("../../../../../../lib/services/session-service", () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
+  sanitizeDisplayName: (value: string) => value.trim(),
+  setInviteeDisplayName: (...args: unknown[]) => mockSetInviteeDisplayName(...args),
 }));
 
 const mockGetPreferences = vi.fn();
@@ -62,6 +65,7 @@ function makeParams(id = SESSION_ID) {
 /** A valid preference payload — the baseline for tests that modify one field */
 const validBody = {
   role: "b",
+  displayName: "Jordan",
   location: { lat: 30.2672, lng: -97.7431, label: "Downtown Austin" },
   budget: "MODERATE",
   categories: ["RESTAURANT", "BAR"],
@@ -72,6 +76,7 @@ const fakeSession = {
   id: SESSION_ID,
   status: "pending_b",
   creatorDisplayName: "Alex",
+  inviteeDisplayName: null,
   createdAt: new Date("2026-03-27T12:00:00Z"),
   expiresAt: new Date("2026-03-29T12:00:00Z"),
   matchedVenueId: null,
@@ -104,6 +109,7 @@ describe("POST /api/sessions/[id]/preferences", () => {
     mockGetSession.mockResolvedValue(fakeSession);
     mockGetPreferences.mockResolvedValue([]);
     mockSubmitPreference.mockResolvedValue(fakePreference);
+    mockSetInviteeDisplayName.mockResolvedValue(undefined);
     mockEnqueueVenueGeneration.mockResolvedValue(undefined);
     mockGenerateVenues.mockResolvedValue(undefined);
     mockGenerateDemoVenues.mockResolvedValue(undefined);
@@ -132,7 +138,18 @@ describe("POST /api/sessions/[id]/preferences", () => {
       budget: "MODERATE",
       categories: ["RESTAURANT", "BAR"],
     });
+    expect(mockSetInviteeDisplayName).toHaveBeenCalledWith(SESSION_ID, "Jordan");
     expect(mockEnqueueVenueGeneration).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when role b does not provide a display name", async () => {
+    const { displayName, ...bodyWithoutName } = validBody;
+
+    const response = await POST(makePostRequest(bodyWithoutName), makeParams());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("displayName is required");
   });
 
   it("binds the submitted role to the browser with a session cookie", async () => {

--- a/web-service/src/app/api/sessions/[id]/preferences/route.ts
+++ b/web-service/src/app/api/sessions/[id]/preferences/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { enqueueVenueGeneration } from "../../../../../lib/qstash";
-import { getSession } from "../../../../../lib/services/session-service";
+import {
+  getSession,
+  sanitizeDisplayName,
+  setInviteeDisplayName,
+} from "../../../../../lib/services/session-service";
 import {
   getPreferences,
   submitPreference,
@@ -42,7 +46,15 @@ const SESSION_ID_PATTERN =
 // ---------------------------------------------------------------------------
 
 type ValidationResult =
-  | { valid: true; role: Role; location: { lat: number; lng: number; label: string }; budget: BudgetLevel; categories: Category[]; demo: boolean }
+  | {
+      valid: true;
+      role: Role;
+      displayName: string | null;
+      location: { lat: number; lng: number; label: string };
+      budget: BudgetLevel;
+      categories: Category[];
+      demo: boolean;
+    }
   | { valid: false; error: string };
 
 function validateBody(body: unknown): ValidationResult {
@@ -50,11 +62,27 @@ function validateBody(body: unknown): ValidationResult {
     return { valid: false, error: "Request body must be a JSON object" };
   }
 
-  const { role, location, budget, categories, demo } = body as Record<string, unknown>;
+  const { role, displayName, location, budget, categories, demo } = body as Record<string, unknown>;
 
   // Role
   if (!role || !VALID_ROLES.includes(role as Role)) {
     return { valid: false, error: "role must be 'a' or 'b'" };
+  }
+
+  let validatedDisplayName: string | null = null;
+  if (role === "b") {
+    if (typeof displayName !== "string") {
+      return { valid: false, error: "displayName is required" };
+    }
+
+    try {
+      validatedDisplayName = sanitizeDisplayName(displayName);
+    } catch (error) {
+      return {
+        valid: false,
+        error: error instanceof Error ? error.message : "displayName is invalid",
+      };
+    }
   }
 
   // Location
@@ -100,6 +128,7 @@ function validateBody(body: unknown): ValidationResult {
   return {
     valid: true,
     role: role as Role,
+    displayName: validatedDisplayName,
     location: { lat: lat as number, lng: lng as number, label: (label as string).trim() },
     budget: budget as BudgetLevel,
     categories: categories as Category[],
@@ -155,7 +184,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     return NextResponse.json({ error: validation.error }, { status: 400 });
   }
 
-  const { role, location, budget, categories, demo } = validation;
+  const { role, displayName, location, budget, categories, demo } = validation;
 
   try {
     // 3. Check session exists
@@ -203,6 +232,10 @@ export async function POST(request: Request, { params }: RouteParams) {
       budget,
       categories,
     });
+
+    if (role === "b" && displayName) {
+      await setInviteeDisplayName(id, displayName);
+    }
 
     const response = NextResponse.json(
       { preference: serializePreference(preference) },

--- a/web-service/src/app/api/sessions/[id]/result/__tests__/route.test.ts
+++ b/web-service/src/app/api/sessions/[id]/result/__tests__/route.test.ts
@@ -31,6 +31,10 @@ describe("GET /api/sessions/[id]/result", () => {
         lng: -97.74,
         priceLevel: 2,
         rating: 4.6,
+        photoUrls: [
+          "https://example.com/photo.jpg",
+          "https://example.com/photo-2.jpg",
+        ],
         photoUrl: "https://example.com/photo.jpg",
         tags: ["cozy", "patio"],
         round: 3,
@@ -63,6 +67,10 @@ describe("GET /api/sessions/[id]/result", () => {
           id: "venue-12",
           placeId: "place-12",
           name: "Cafe Blue",
+          photoUrls: [
+            "https://example.com/photo.jpg",
+            "https://example.com/photo-2.jpg",
+          ],
         }),
       },
     });

--- a/web-service/src/app/layout.tsx
+++ b/web-service/src/app/layout.tsx
@@ -7,7 +7,22 @@ const inter = Inter({
   subsets: ["latin"],
 });
 
+function getMetadataBase(): URL | undefined {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim();
+
+  if (!appUrl) {
+    return undefined;
+  }
+
+  try {
+    return new URL(appUrl);
+  } catch {
+    return undefined;
+  }
+}
+
 export const metadata: Metadata = {
+  metadataBase: getMetadataBase(),
   title: "Dateflow",
   description:
     "AI-powered first date planning. From 'we should hang out' to 'we have a plan' in under 2 minutes.",

--- a/web-service/src/app/plan/[id]/plan-flow.tsx
+++ b/web-service/src/app/plan/[id]/plan-flow.tsx
@@ -38,6 +38,7 @@ export function PlanFlow({
   const router = useRouter();
   const [step, setStep] = useState<FlowStep>(initialStep);
   const [location, setLocation] = useState<Location | null>(null);
+  const [inviteeDisplayName, setInviteeDisplayName] = useState("");
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   async function submitPreferences(
@@ -53,6 +54,7 @@ export function PlanFlow({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             role: "b",
+            displayName: inviteeDisplayName,
             location: { lat: loc.lat, lng: loc.lng, label: loc.label },
             budget: vibeBudget,
             categories: vibeCategories,
@@ -95,9 +97,13 @@ export function PlanFlow({
 
   if (step === "hook") {
     return (
-      <HookScreen
-        creatorName={creatorName}
-        onContinue={() => setStep("location")}
+        <HookScreen
+          creatorName={creatorName}
+          initialDisplayName={inviteeDisplayName}
+          onContinue={(displayName) => {
+            setInviteeDisplayName(displayName);
+            setStep("location");
+          }}
       />
     );
   }

--- a/web-service/src/app/plan/[id]/results/__tests__/page.test.tsx
+++ b/web-service/src/app/plan/[id]/results/__tests__/page.test.tsx
@@ -48,6 +48,10 @@ describe("/plan/[id]/results page", () => {
         lng: -97.74,
         priceLevel: 2,
         rating: 4.6,
+        photoUrls: [
+          "https://example.com/cafe-blue.jpg",
+          "https://example.com/cafe-blue-2.jpg",
+        ],
         photoUrl: "https://example.com/cafe-blue.jpg",
         tags: ["cozy patio", "walkable"],
         round: 1,
@@ -91,6 +95,10 @@ describe("/plan/[id]/results page", () => {
     expect(metadata.openGraph?.images).toEqual([
       {
         url: "https://example.com/cafe-blue.jpg",
+        alt: "Cafe Blue",
+      },
+      {
+        url: "https://example.com/cafe-blue-2.jpg",
         alt: "Cafe Blue",
       },
     ]);

--- a/web-service/src/app/plan/[id]/results/__tests__/page.test.tsx
+++ b/web-service/src/app/plan/[id]/results/__tests__/page.test.tsx
@@ -1,91 +1,126 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockGetMatchResult = vi.fn();
-const mockGetSession = vi.fn();
+const mockCookieGet = vi.fn();
 const mockNotFound = vi.fn(() => {
   throw new Error("NEXT_NOT_FOUND");
 });
 
-vi.mock("../../../../../../lib/services/result-service", () => ({
-  getMatchResult: (...args: unknown[]) => mockGetMatchResult(...args),
+const matchedSessionRow = {
+  id: "session-1",
+  status: "matched",
+  creator_display_name: "Alex",
+  invitee_display_name: "Jordan",
+  created_at: "2026-04-02T18:30:00Z",
+  expires_at: "2026-04-04T18:30:00Z",
+  matched_venue_id: "venue-12",
+  matched_at: "2026-04-02T18:30:00Z",
+};
+
+const matchedVenueRow = {
+  id: "venue-12",
+  session_id: "session-1",
+  place_id: "place-12",
+  name: "Cafe Blue",
+  category: "RESTAURANT",
+  address: "12 Main St, Austin, TX",
+  lat: 30.26,
+  lng: -97.74,
+  price_level: 2,
+  rating: 4.6,
+  photo_urls: [
+    "https://example.com/cafe-blue.jpg",
+    "https://example.com/cafe-blue-2.jpg",
+  ],
+  photo_url: "https://example.com/cafe-blue.jpg",
+  tags: ["cozy patio", "walkable"],
+  round: 1,
+  position: 1,
+  score_category_overlap: 0.9,
+  score_distance_to_midpoint: 0.8,
+  score_first_date_suitability: 0.95,
+  score_quality_signal: 0.85,
+  score_time_of_day_fit: 0.75,
+};
+
+vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.test");
+vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === "sessions") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({
+                data: matchedSessionRow,
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+
+      if (table === "venues") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: async () => ({
+                  data: matchedVenueRow,
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  }),
 }));
 
-vi.mock("../../../../../../lib/services/session-service", () => ({
-  getSession: (...args: unknown[]) => mockGetSession(...args),
+vi.mock("../../../../../../lib/session-role-access", () => ({
+  getBoundSessionRole: () => "a",
+  getSessionRoleCookieName: () => "test-cookie",
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (...args: unknown[]) => mockCookieGet(...args),
+  }),
 }));
 
 vi.mock("next/navigation", () => ({
   notFound: () => mockNotFound(),
 }));
 
-import ResultPage, { generateMetadata } from "../page";
-
 describe("/plan/[id]/results page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    mockGetSession.mockResolvedValue({
-      id: "session-1",
-      status: "matched",
-      creatorDisplayName: "Alex",
-      createdAt: new Date("2026-04-02T18:30:00Z"),
-      expiresAt: new Date("2026-04-04T18:30:00Z"),
-      matchedVenueId: "venue-12",
-    });
-
-    mockGetMatchResult.mockResolvedValue({
-      sessionId: "session-1",
-      matchedAt: new Date("2026-04-02T18:30:00Z"),
-      venue: {
-        id: "venue-12",
-        sessionId: "session-1",
-        placeId: "place-12",
-        name: "Cafe Blue",
-        category: "RESTAURANT",
-        address: "12 Main St, Austin, TX",
-        lat: 30.26,
-        lng: -97.74,
-        priceLevel: 2,
-        rating: 4.6,
-        photoUrls: [
-          "https://example.com/cafe-blue.jpg",
-          "https://example.com/cafe-blue-2.jpg",
-        ],
-        photoUrl: "https://example.com/cafe-blue.jpg",
-        tags: ["cozy patio", "walkable"],
-        round: 1,
-        position: 1,
-        score: {
-          categoryOverlap: 0.9,
-          distanceToMidpoint: 0.8,
-          firstDateSuitability: 0.95,
-          qualitySignal: 0.85,
-          timeOfDayFit: 0.75,
-          composite: 0.875,
-        },
-      },
-    });
+    mockCookieGet.mockReturnValue({ value: "a.test" });
   });
 
   it("renders the matched venue reveal with the primary actions", async () => {
+    const { default: ResultPage } = await import("../page");
     const page = await ResultPage({
       params: Promise.resolve({ id: "session-1" }),
     });
 
     const html = renderToStaticMarkup(page);
 
-    expect(mockGetSession).toHaveBeenCalledWith("session-1");
-    expect(mockGetMatchResult).toHaveBeenCalledWith("session-1");
     expect(html).toContain("It’s a match");
     expect(html).toContain("Cafe Blue");
-    expect(html).toContain("You and Alex both liked this spot");
+    expect(html).toContain("both liked this spot");
     expect(html).toContain("12 Main St, Austin, TX");
     expect(html).toContain("Get directions");
     expect(html).toContain("Add to calendar");
   });
 
   it("builds result-page metadata from the matched venue", async () => {
+    const { generateMetadata } = await import("../page");
     const metadata = await generateMetadata({
       params: Promise.resolve({ id: "session-1" }),
     });

--- a/web-service/src/app/plan/[id]/results/__tests__/result-screen.test.tsx
+++ b/web-service/src/app/plan/[id]/results/__tests__/result-screen.test.tsx
@@ -1,0 +1,56 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { ResultScreen } from "../result-screen";
+
+vi.mock("next/image", () => ({
+  default: (props: Record<string, unknown>) => {
+    const { alt, src } = props;
+    return `<img alt="${String(alt ?? "")}" src="${String(src ?? "")}" />`;
+  },
+}));
+
+describe("ResultScreen", () => {
+  it("renders a multi-photo filmstrip when the matched venue has more than one image", () => {
+    const html = renderToStaticMarkup(
+      <ResultScreen
+        creatorName="Alex"
+        matchResult={{
+          sessionId: "session-1",
+          matchedAt: new Date("2026-04-02T18:30:00Z"),
+          venue: {
+            id: "venue-12",
+            sessionId: "session-1",
+            placeId: "place-12",
+            name: "Cafe Blue",
+            category: "RESTAURANT",
+            address: "12 Main St, Austin, TX",
+            lat: 30.26,
+            lng: -97.74,
+            priceLevel: 2,
+            rating: 4.6,
+            photoUrls: [
+              "https://example.com/cafe-blue.jpg",
+              "https://example.com/cafe-blue-2.jpg",
+              "https://example.com/cafe-blue-3.jpg",
+            ],
+            photoUrl: "https://example.com/cafe-blue.jpg",
+            tags: ["cozy patio", "walkable"],
+            round: 1,
+            position: 1,
+            score: {
+              categoryOverlap: 0.9,
+              distanceToMidpoint: 0.8,
+              firstDateSuitability: 0.95,
+              qualitySignal: 0.85,
+              timeOfDayFit: 0.75,
+              composite: 0.875,
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Photo gallery");
+    expect(html).toContain("3 photos");
+  });
+});

--- a/web-service/src/app/plan/[id]/results/__tests__/result-screen.test.tsx
+++ b/web-service/src/app/plan/[id]/results/__tests__/result-screen.test.tsx
@@ -13,7 +13,7 @@ describe("ResultScreen", () => {
   it("renders a multi-photo filmstrip when the matched venue has more than one image", () => {
     const html = renderToStaticMarkup(
       <ResultScreen
-        creatorName="Alex"
+        matchedWithName="Alex"
         matchResult={{
           sessionId: "session-1",
           matchedAt: new Date("2026-04-02T18:30:00Z"),
@@ -52,5 +52,44 @@ describe("ResultScreen", () => {
 
     expect(html).toContain("Photo gallery");
     expect(html).toContain("3 photos");
+  });
+
+  it("falls back to neutral shared-like copy when the counterpart name is unknown", () => {
+    const html = renderToStaticMarkup(
+      <ResultScreen
+        matchedWithName={null}
+        matchResult={{
+          sessionId: "session-1",
+          matchedAt: new Date("2026-04-02T18:30:00Z"),
+          venue: {
+            id: "venue-12",
+            sessionId: "session-1",
+            placeId: "place-12",
+            name: "Cafe Blue",
+            category: "RESTAURANT",
+            address: "12 Main St, Austin, TX",
+            lat: 30.26,
+            lng: -97.74,
+            priceLevel: 2,
+            rating: 4.6,
+            photoUrls: [],
+            photoUrl: null,
+            tags: ["cozy patio"],
+            round: 1,
+            position: 1,
+            score: {
+              categoryOverlap: 0.9,
+              distanceToMidpoint: 0.8,
+              firstDateSuitability: 0.95,
+              qualitySignal: 0.85,
+              timeOfDayFit: 0.75,
+              composite: 0.875,
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("You both liked this spot.");
   });
 });

--- a/web-service/src/app/plan/[id]/results/page.tsx
+++ b/web-service/src/app/plan/[id]/results/page.tsx
@@ -24,6 +24,13 @@ export async function generateMetadata({
     };
   }
 
+  const galleryImages =
+    matchResult.venue.photoUrls.length > 0
+      ? matchResult.venue.photoUrls
+      : matchResult.venue.photoUrl
+        ? [matchResult.venue.photoUrl]
+        : [];
+
   return {
     title: `${session.creatorDisplayName} matched on ${matchResult.venue.name}`,
     description: "See your matched venue, Get directions, and add it to your calendar.",
@@ -33,21 +40,20 @@ export async function generateMetadata({
         "See your matched venue, Get directions, and add it to your calendar.",
       siteName: "Dateflow",
       type: "website",
-      images: matchResult.venue.photoUrl
-        ? [
-            {
-              url: matchResult.venue.photoUrl,
+      images:
+        galleryImages.length > 0
+          ? galleryImages.map((url) => ({
+              url,
               alt: matchResult.venue.name,
-            },
-          ]
-        : undefined,
+            }))
+          : undefined,
     },
     twitter: {
       card: "summary_large_image",
       title: `${session.creatorDisplayName} matched on ${matchResult.venue.name}`,
       description:
         "See your matched venue, Get directions, and add it to your calendar.",
-      images: matchResult.venue.photoUrl ? [matchResult.venue.photoUrl] : undefined,
+      images: galleryImages.length > 0 ? [...galleryImages] : undefined,
     },
   };
 }

--- a/web-service/src/app/plan/[id]/results/page.tsx
+++ b/web-service/src/app/plan/[id]/results/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
-import { getMatchResult } from "../../../../../lib/services/result-service";
-import { getSession } from "../../../../../lib/services/session-service";
+import { getMatchResult } from "../../../../lib/services/result-service";
+import { getSession } from "../../../../lib/services/session-service";
+import {
+  getBoundSessionRole,
+  getSessionRoleCookieName,
+} from "../../../../lib/session-role-access";
 import { ResultScreen } from "./result-screen";
 
 type PageProps = {
@@ -69,9 +74,19 @@ export default async function ResultPage({ params }: PageProps) {
     notFound();
   }
 
+  const cookieStore = await cookies();
+  const viewerRole = getBoundSessionRole(
+    id,
+    cookieStore.get(getSessionRoleCookieName(id))?.value,
+  );
+  const matchedWithName =
+    viewerRole === "a"
+      ? session.inviteeDisplayName
+      : session.creatorDisplayName;
+
   return (
     <ResultScreen
-      creatorName={session.creatorDisplayName}
+      matchedWithName={matchedWithName}
       matchResult={matchResult}
     />
   );

--- a/web-service/src/app/plan/[id]/results/page.tsx
+++ b/web-service/src/app/plan/[id]/results/page.tsx
@@ -35,6 +35,7 @@ export async function generateMetadata({
       : matchResult.venue.photoUrl
         ? [matchResult.venue.photoUrl]
         : [];
+  const socialImages = galleryImages.slice(0, 3);
 
   return {
     title: `${session.creatorDisplayName} matched on ${matchResult.venue.name}`,
@@ -46,8 +47,8 @@ export async function generateMetadata({
       siteName: "Dateflow",
       type: "website",
       images:
-        galleryImages.length > 0
-          ? galleryImages.map((url) => ({
+        socialImages.length > 0
+          ? socialImages.map((url) => ({
               url,
               alt: matchResult.venue.name,
             }))
@@ -58,7 +59,7 @@ export async function generateMetadata({
       title: `${session.creatorDisplayName} matched on ${matchResult.venue.name}`,
       description:
         "See your matched venue, Get directions, and add it to your calendar.",
-      images: galleryImages.length > 0 ? [...galleryImages] : undefined,
+      images: socialImages.length > 0 ? [...socialImages] : undefined,
     },
   };
 }

--- a/web-service/src/app/plan/[id]/results/result-screen.tsx
+++ b/web-service/src/app/plan/[id]/results/result-screen.tsx
@@ -32,6 +32,7 @@ export function ResultScreen({
   matchResult,
 }: ResultScreenProps) {
   const { venue } = matchResult;
+  const galleryImages = getVenueGalleryImages(venue);
   const [directionsUrl, setDirectionsUrl] = useState(() =>
     getResultDirectionsHref(venue, ""),
   );
@@ -113,9 +114,9 @@ export function ResultScreen({
             }}
           >
             <div className="relative aspect-[4/3] overflow-hidden bg-[linear-gradient(135deg,var(--color-secondary-muted),var(--color-primary-muted))]">
-              {venue.photoUrl ? (
+              {galleryImages.length > 0 ? (
                 <Image
-                  src={venue.photoUrl}
+                  src={galleryImages[0]}
                   alt={venue.name}
                   fill
                   sizes="(max-width: 1024px) 100vw, 520px"
@@ -137,6 +138,42 @@ export function ResultScreen({
             </div>
 
             <div className="space-y-5 p-6">
+              {galleryImages.length > 1 ? (
+                <section className="space-y-3" aria-label="Photo gallery">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-caption font-semibold uppercase tracking-[0.18em] text-secondary">
+                        Photo gallery
+                      </p>
+                      <p className="mt-1 text-body text-text-secondary">
+                        {galleryImages.length} photos
+                      </p>
+                    </div>
+                    <div className="hidden rounded-full border border-muted bg-bg px-3 py-1.5 text-caption font-medium text-text-secondary sm:inline-flex">
+                      Swipe-worthy details
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-3 gap-3">
+                    {galleryImages.slice(0, 3).map((photoUrl, photoIndex) => (
+                      <div
+                        key={`${photoUrl}-${photoIndex}`}
+                        className="relative aspect-[5/4] overflow-hidden rounded-[1.25rem] border border-white/70 bg-bg shadow-[0_10px_24px_rgba(45,42,38,0.08)]"
+                      >
+                        <Image
+                          src={photoUrl}
+                          alt={`${venue.name} photo ${photoIndex + 1}`}
+                          fill
+                          sizes="(max-width: 1024px) 33vw, 150px"
+                          className="object-cover"
+                          unoptimized
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
               <div className="space-y-3">
                 <div className="flex items-start justify-between gap-4">
                   <div>
@@ -209,6 +246,16 @@ function StarIcon() {
       <path d="M12 3.75 14.78 9l5.72.78-4.13 4 1 5.72L12 16.98 6.63 19.5l1-5.72-4.13-4L9.22 9 12 3.75Z" />
     </svg>
   );
+}
+
+function getVenueGalleryImages(
+  venue: MatchResult["venue"],
+): readonly string[] {
+  if (venue.photoUrls.length > 0) {
+    return venue.photoUrls;
+  }
+
+  return venue.photoUrl ? [venue.photoUrl] : [];
 }
 
 function toPriceLabel(priceLevel: number): string {

--- a/web-service/src/app/plan/[id]/results/result-screen.tsx
+++ b/web-service/src/app/plan/[id]/results/result-screen.tsx
@@ -16,7 +16,7 @@ import {
 } from "./result-screen-state";
 
 type ResultScreenProps = {
-  readonly creatorName: string;
+  readonly matchedWithName: string | null;
   readonly matchResult: MatchResult;
 };
 
@@ -28,7 +28,7 @@ const CATEGORY_LABELS: Record<Category, string> = {
 };
 
 export function ResultScreen({
-  creatorName,
+  matchedWithName,
   matchResult,
 }: ResultScreenProps) {
   const { venue } = matchResult;
@@ -50,6 +50,10 @@ export function ResultScreen({
 
     return () => window.cancelAnimationFrame(frame);
   }, [venue]);
+
+  const sharedLikeCopy = matchedWithName
+    ? `You and ${matchedWithName} both liked this spot.`
+    : "You both liked this spot.";
 
   return (
     <main className="relative min-h-dvh overflow-hidden bg-bg text-text">
@@ -82,7 +86,7 @@ export function ResultScreen({
               It’s a match
             </h1>
             <p className="mt-5 max-w-xl text-[1.05rem] leading-7 text-text-secondary">
-              You and {creatorName} both liked this spot. The hard part is over.
+              {sharedLikeCopy} The hard part is over.
               Now you just need the plan.
             </p>
 
@@ -190,7 +194,9 @@ export function ResultScreen({
                   </div>
                   <div className="inline-flex items-center gap-2 rounded-full bg-primary-muted px-3 py-1.5 text-primary">
                     <HeartIcon />
-                    You and {creatorName} both liked this spot
+                    {matchedWithName
+                      ? `You and ${matchedWithName} both liked this spot`
+                      : "You both liked this spot"}
                   </div>
                 </div>
               </div>

--- a/web-service/src/app/plan/[id]/swipe/__tests__/fallback-ending-state.test.ts
+++ b/web-service/src/app/plan/[id]/swipe/__tests__/fallback-ending-state.test.ts
@@ -18,7 +18,7 @@ const venues: readonly Venue[] = [
     lng: -97.74,
     priceLevel: 2,
     rating: 4.7,
-    photoUrl: "https://dateflow.test/api/places/photos?name=places%2Fabc%2Fphotos%2Fref",
+    photoUrl: "/api/places/photos?name=places%2Fabc%2Fphotos%2Fref",
     tags: ["cozy patio"],
     round: 2,
     position: 3,

--- a/web-service/src/app/plan/[id]/swipe/__tests__/swipe-deck-card.test.ts
+++ b/web-service/src/app/plan/[id]/swipe/__tests__/swipe-deck-card.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { Venue } from "../../../../../../lib/types/venue";
+import { getVenueSlides } from "../swipe-deck-card";
+
+function makeVenue(overrides: Partial<Venue> = {}): Venue {
+  return {
+    id: "venue-1",
+    sessionId: "session-1",
+    placeId: "place-1",
+    name: "Cafe Blue",
+    category: "RESTAURANT",
+    address: "12 Main St, Austin, TX",
+    lat: 30.26,
+    lng: -97.74,
+    priceLevel: 2,
+    rating: 4.6,
+    photoUrls: [],
+    photoUrl: null,
+    tags: ["cozy"],
+    round: 1,
+    position: 1,
+    score: {
+      categoryOverlap: 0.9,
+      distanceToMidpoint: 0.8,
+      firstDateSuitability: 0.95,
+      qualitySignal: 0.85,
+      timeOfDayFit: 0.75,
+      composite: 0.875,
+    },
+    ...overrides,
+  };
+}
+
+describe("getVenueSlides", () => {
+  it("returns the full photo collection when multiple photos exist", () => {
+    const venue = makeVenue({
+      photoUrls: [
+        "https://example.com/photo-1.jpg",
+        "https://example.com/photo-2.jpg",
+        "https://example.com/photo-3.jpg",
+      ],
+      photoUrl: "https://example.com/photo-1.jpg",
+    });
+
+    expect(getVenueSlides(venue)).toEqual([
+      "https://example.com/photo-1.jpg",
+      "https://example.com/photo-2.jpg",
+      "https://example.com/photo-3.jpg",
+    ]);
+  });
+
+  it("falls back to the primary photo for legacy single-photo venues", () => {
+    const venue = makeVenue({
+      photoUrls: [],
+      photoUrl: "https://example.com/legacy-photo.jpg",
+    });
+
+    expect(getVenueSlides(venue)).toEqual([
+      "https://example.com/legacy-photo.jpg",
+    ]);
+  });
+});

--- a/web-service/src/app/plan/[id]/swipe/__tests__/swipe-deck-card.test.ts
+++ b/web-service/src/app/plan/[id]/swipe/__tests__/swipe-deck-card.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Venue } from "../../../../../../lib/types/venue";
-import { getVenueSlides } from "../swipe-deck-card";
+import { clampSlideIndex, getVenueSlides } from "../swipe-deck-card";
 
 function makeVenue(overrides: Partial<Venue> = {}): Venue {
   return {
@@ -58,5 +58,12 @@ describe("getVenueSlides", () => {
     expect(getVenueSlides(venue)).toEqual([
       "https://example.com/legacy-photo.jpg",
     ]);
+  });
+
+  it("wraps gallery indexes across the available photo count", () => {
+    expect(clampSlideIndex(-1, 3)).toBe(2);
+    expect(clampSlideIndex(3, 3)).toBe(0);
+    expect(clampSlideIndex(1, 3)).toBe(1);
+    expect(clampSlideIndex(0, 0)).toBe(0);
   });
 });

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -63,6 +63,7 @@ export function SwipeDeckCard({
   const [animatingSwipe, setAnimatingSwipe] = useState<SwipeAnimation | null>(null);
   const [isSettled, setIsSettled] = useState(false);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [activeSlideIndex, setActiveSlideIndex] = useState(0);
 
   useEffect(() => {
     let secondFrame: number | null = null;
@@ -93,8 +94,13 @@ export function SwipeDeckCard({
     return () => media.removeEventListener("change", updatePreference);
   }, []);
 
+  useEffect(() => {
+    setActiveSlideIndex(0);
+  }, [venue.id]);
+
   const currentSlides = getVenueSlides(venue);
   const nextSlides = nextVenue ? getVenueSlides(nextVenue) : [];
+  const activeSlide = currentSlides[activeSlideIndex] ?? currentSlides[0] ?? null;
   const dragOffsetX = dragState?.offsetX ?? 0;
   const dragOffsetY = dragState?.offsetY ?? 0;
   const dragRatio = clamp(dragOffsetX / SWIPE_TRIGGER_PX, -1.3, 1.3);
@@ -250,6 +256,14 @@ export function SwipeDeckCard({
     }
   }
 
+  function moveToSlide(nextIndex: number) {
+    if (currentSlides.length <= 1) {
+      return;
+    }
+
+    setActiveSlideIndex(clampSlideIndex(nextIndex, currentSlides.length));
+  }
+
   return (
     <div className="relative min-h-[640px]">
       <div
@@ -367,12 +381,13 @@ export function SwipeDeckCard({
         </div>
 
         <div className="relative aspect-[4/3] overflow-hidden bg-[linear-gradient(135deg,var(--color-secondary-muted),var(--color-primary-muted))]">
-          {currentSlides.length > 0 ? (
+          {activeSlide ? (
             <Image
-              src={currentSlides[0]}
+              src={activeSlide}
               alt={venue.name}
               fill
               sizes="(max-width: 768px) 100vw, 480px"
+              loading="eager"
               className="object-cover"
               unoptimized
               style={{
@@ -395,7 +410,7 @@ export function SwipeDeckCard({
             </div>
           )}
 
-          <div className="absolute inset-x-0 bottom-0 h-28 bg-[linear-gradient(180deg,transparent,rgba(28,25,23,0.56))]" />
+          <div className="absolute inset-x-0 bottom-0 h-18 bg-[linear-gradient(180deg,transparent,rgba(28,25,23,0.26))]" />
           <div
             className="absolute inset-0"
             style={{
@@ -411,60 +426,38 @@ export function SwipeDeckCard({
             {CATEGORY_LABELS[venue.category]}
           </div>
 
-          <div className="absolute bottom-4 left-4 right-4 z-20 flex items-end justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-caption font-semibold uppercase tracking-[0.18em] text-white/74">
-                Venue {cardIndex} of {totalCards}
-              </p>
-              <h2 className="mt-2 text-[clamp(2rem,5vw,2.7rem)] font-semibold leading-[0.97] tracking-[-0.04em] text-white">
-                {venue.name}
-              </h2>
-            </div>
-            <div className="hidden sm:block">
-              <PriceBadge priceLevel={venue.priceLevel} />
-            </div>
-          </div>
-
           {currentSlides.length > 1 ? (
-            <div className="absolute right-4 top-16 z-20 flex items-center gap-2 rounded-[1.15rem] border border-white/24 bg-black/22 px-2.5 py-2 text-white backdrop-blur-md">
-              <div className="flex -space-x-3">
-                {currentSlides.slice(0, 3).map((slide, slideIndex) => (
-                  <div
-                    key={`${slide}-${slideIndex}`}
-                    className="relative h-11 w-11 overflow-hidden rounded-[0.95rem] border border-white/45 shadow-[0_8px_18px_rgba(15,23,42,0.28)]"
-                  >
-                    <Image
-                      src={slide}
-                      alt=""
-                      fill
-                      sizes="44px"
-                      className="object-cover"
-                      unoptimized
-                    />
-                  </div>
-                ))}
-              </div>
-              <div className="min-w-0">
-                <p className="text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-white/68">
-                  Gallery
-                </p>
-                <p className="text-caption font-medium text-white">
-                  {currentSlides.length} photos
-                </p>
-              </div>
-            </div>
+            <>
+              <button
+                type="button"
+                aria-label="Show previous venue photo"
+                className="absolute left-6 top-1/2 z-20 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full border border-white/40 bg-black/20 text-white shadow-[0_10px_24px_rgba(15,23,42,0.24)] backdrop-blur-md transition-colors hover:bg-black/32"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  moveToSlide(activeSlideIndex - 1);
+                }}
+                onPointerDown={(event) => event.stopPropagation()}
+              >
+                <ChevronIcon direction="left" />
+              </button>
+              <button
+                type="button"
+                aria-label="Show next venue photo"
+                className="absolute right-6 top-1/2 z-20 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full border border-white/40 bg-black/20 text-white shadow-[0_10px_24px_rgba(15,23,42,0.24)] backdrop-blur-md transition-colors hover:bg-black/32"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  moveToSlide(activeSlideIndex + 1);
+                }}
+                onPointerDown={(event) => event.stopPropagation()}
+              >
+                <ChevronIcon direction="right" />
+              </button>
+            </>
           ) : null}
 
           {currentSlides.length > 1 ? (
-            <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-1.5 rounded-full bg-black/20 px-2 py-1 backdrop-blur-sm">
-              {currentSlides.map((slide, slideIndex) => (
-                <span
-                  key={`${slide}-${slideIndex}`}
-                  className={`rounded-full transition-all duration-200 ${
-                    slideIndex === 0 ? "h-1.5 w-5 bg-white" : "h-1.5 w-1.5 bg-white/45"
-                  }`}
-                />
-              ))}
+            <div className="absolute right-4 top-4 z-20 rounded-full border border-white/28 bg-black/20 px-3 py-1.5 text-caption font-medium text-white shadow-[0_10px_24px_rgba(15,23,42,0.22)] backdrop-blur-md">
+              {activeSlideIndex + 1} / {currentSlides.length}
             </div>
           ) : null}
         </div>
@@ -472,8 +465,16 @@ export function SwipeDeckCard({
         <div className="space-y-4 p-6">
           <div className="rounded-[1.5rem] border border-muted bg-bg/72 p-4">
             <div className="flex items-start justify-between gap-4">
-              <div className="min-w-0">
-                <p className="text-body text-text-secondary">{venue.address}</p>
+              <div className="min-w-0 space-y-3">
+                <div>
+                  <p className="text-caption font-semibold uppercase tracking-[0.16em] text-text-secondary">
+                    Venue {cardIndex} of {totalCards}
+                  </p>
+                  <h2 className="mt-2 text-[clamp(1.9rem,4vw,2.5rem)] font-semibold leading-[0.98] tracking-[-0.04em] text-text">
+                    {venue.name}
+                  </h2>
+                  <p className="mt-2 text-body text-text-secondary">{venue.address}</p>
+                </div>
                 <div className="mt-4 flex flex-wrap gap-2">
                   <InfoPill>
                     <StarIcon />
@@ -491,6 +492,55 @@ export function SwipeDeckCard({
               </div>
             </div>
           </div>
+
+          {currentSlides.length > 1 ? (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-caption font-semibold uppercase tracking-[0.16em] text-text-secondary">
+                  Venue photos
+                </p>
+                <div className="flex items-center gap-1.5">
+                  {currentSlides.map((slide, slideIndex) => (
+                    <button
+                      type="button"
+                      key={`${slide}-${slideIndex}`}
+                      aria-label={`Show photo ${slideIndex + 1} of ${currentSlides.length}`}
+                      className={`rounded-full transition-all duration-200 ${
+                        slideIndex === activeSlideIndex
+                          ? "h-1.5 w-5 bg-primary"
+                          : "h-1.5 w-1.5 bg-muted"
+                      }`}
+                      onClick={() => moveToSlide(slideIndex)}
+                    />
+                  ))}
+                </div>
+              </div>
+              <div className="flex gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                {currentSlides.map((slide, slideIndex) => (
+                  <button
+                    type="button"
+                    key={`${slide}-thumb-${slideIndex}`}
+                    aria-label={`Show photo ${slideIndex + 1} of ${currentSlides.length}`}
+                    className={`relative h-20 min-w-24 overflow-hidden rounded-[1.1rem] border bg-bg shadow-[0_10px_24px_rgba(45,42,38,0.08)] ${
+                      slideIndex === activeSlideIndex
+                        ? "border-primary ring-2 ring-primary/20"
+                        : "border-muted"
+                    }`}
+                    onClick={() => moveToSlide(slideIndex)}
+                  >
+                    <Image
+                      src={slide}
+                      alt={`${venue.name} photo ${slideIndex + 1}`}
+                      fill
+                      sizes="96px"
+                      className="object-cover"
+                      unoptimized
+                    />
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
 
           <div className="flex flex-wrap gap-2">
             {venue.tags.slice(0, 3).map((tag) => (
@@ -673,12 +723,49 @@ function HeartIcon() {
   );
 }
 
+function ChevronIcon({ direction }: { readonly direction: "left" | "right" }) {
+  return (
+    <svg
+      className="h-5 w-5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {direction === "left" ? (
+        <path d="m15 18-6-6 6-6" />
+      ) : (
+        <path d="m9 18 6-6-6-6" />
+      )}
+    </svg>
+  );
+}
+
 export function getVenueSlides(venue: Venue): readonly string[] {
   if (venue.photoUrls.length > 0) {
     return venue.photoUrls;
   }
 
   return venue.photoUrl ? [venue.photoUrl] : [];
+}
+
+export function clampSlideIndex(index: number, totalSlides: number): number {
+  if (totalSlides <= 0) {
+    return 0;
+  }
+
+  if (index < 0) {
+    return totalSlides - 1;
+  }
+
+  if (index >= totalSlides) {
+    return 0;
+  }
+
+  return index;
 }
 
 function getCardTransform(

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -94,10 +94,6 @@ export function SwipeDeckCard({
     return () => media.removeEventListener("change", updatePreference);
   }, []);
 
-  useEffect(() => {
-    setActiveSlideIndex(0);
-  }, [venue.id]);
-
   const currentSlides = getVenueSlides(venue);
   const nextSlides = nextVenue ? getVenueSlides(nextVenue) : [];
   const activeSlide = currentSlides[activeSlideIndex] ?? currentSlides[0] ?? null;

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -426,6 +426,36 @@ export function SwipeDeckCard({
           </div>
 
           {currentSlides.length > 1 ? (
+            <div className="absolute right-4 top-16 z-20 flex items-center gap-2 rounded-[1.15rem] border border-white/24 bg-black/22 px-2.5 py-2 text-white backdrop-blur-md">
+              <div className="flex -space-x-3">
+                {currentSlides.slice(0, 3).map((slide, slideIndex) => (
+                  <div
+                    key={`${slide}-${slideIndex}`}
+                    className="relative h-11 w-11 overflow-hidden rounded-[0.95rem] border border-white/45 shadow-[0_8px_18px_rgba(15,23,42,0.28)]"
+                  >
+                    <Image
+                      src={slide}
+                      alt=""
+                      fill
+                      sizes="44px"
+                      className="object-cover"
+                      unoptimized
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="min-w-0">
+                <p className="text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-white/68">
+                  Gallery
+                </p>
+                <p className="text-caption font-medium text-white">
+                  {currentSlides.length} photos
+                </p>
+              </div>
+            </div>
+          ) : null}
+
+          {currentSlides.length > 1 ? (
             <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-1.5 rounded-full bg-black/20 px-2 py-1 backdrop-blur-sm">
               {currentSlides.map((slide, slideIndex) => (
                 <span
@@ -643,7 +673,11 @@ function HeartIcon() {
   );
 }
 
-function getVenueSlides(venue: Venue): readonly string[] {
+export function getVenueSlides(venue: Venue): readonly string[] {
+  if (venue.photoUrls.length > 0) {
+    return venue.photoUrls;
+  }
+
   return venue.photoUrl ? [venue.photoUrl] : [];
 }
 

--- a/web-service/src/app/plan/[id]/swipe/swipe-flow.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-flow.tsx
@@ -84,6 +84,26 @@ export function SwipeFlow({
   const nextVenue = venues[index + 1] ?? null;
   const progressLabel = useMemo(() => `Round ${round} of 3`, [round]);
 
+  const logVenuePhotoSnapshot = useCallback(
+    (source: "round" | "fallback", nextRound: number | null, nextVenues: readonly Venue[]) => {
+      const firstVenue = nextVenues[0] ?? null;
+
+      console.info("[SwipeFlow] Venue photo snapshot", {
+        source,
+        sessionId,
+        role,
+        round: nextRound,
+        venueCount: nextVenues.length,
+        firstVenueId: firstVenue?.id ?? null,
+        firstVenueName: firstVenue?.name ?? null,
+        photoUrl: firstVenue?.photoUrl ?? null,
+        photoUrlsCount: firstVenue?.photoUrls.length ?? 0,
+        firstPhotoUrl: firstVenue?.photoUrls[0] ?? null,
+      });
+    },
+    [role, sessionId],
+  );
+
   const fetchStatus = useCallback(async (): Promise<SessionStatusPayload> => {
     const response = await fetch(`/api/sessions/${sessionId}/status`);
 
@@ -112,10 +132,11 @@ export function SwipeFlow({
     }
 
     setVenues(body.venues);
+    logVenuePhotoSnapshot("fallback", null, body.venues);
     setFallbackVenue(resolvedVenue);
     setStatus("fallback");
     setStatusMessage("");
-  }, [sessionId]);
+  }, [logVenuePhotoSnapshot, sessionId]);
 
   const loadRound = useCallback(async (nextRound: number) => {
     if (
@@ -141,6 +162,7 @@ export function SwipeFlow({
       roundSwipesRef.current[nextRound] = [];
       setRound(nextRound);
       setVenues(body.venues);
+      logVenuePhotoSnapshot("round", nextRound, body.venues);
       setIndex(0);
       setStatus("ready");
       setStatusMessage("");
@@ -149,7 +171,7 @@ export function SwipeFlow({
         loadingRoundRef.current = null;
       }
     }
-  }, [sessionId]);
+  }, [logVenuePhotoSnapshot, sessionId]);
 
   const bootstrap = useCallback(async () => {
     setStatus("loading");

--- a/web-service/src/components/__tests__/invite-ready-state-sync.test.ts
+++ b/web-service/src/components/__tests__/invite-ready-state-sync.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getInviteReadySessionStatus } from "../person-a-flow";
+import {
+  getInviteReadyRedirectHref,
+  getInviteReadySessionStatus,
+} from "../person-a-flow";
 
 describe("getInviteReadySessionStatus", () => {
   it("keeps neutral waiting states on the invite-ready screen", () => {
@@ -20,5 +23,17 @@ describe("getInviteReadySessionStatus", () => {
     expect(getInviteReadySessionStatus("generation_failed")).toBe("generation_failed");
     expect(getInviteReadySessionStatus("expired")).toBe("expired");
     expect(getInviteReadySessionStatus("unknown_status")).toBe("pending_b");
+  });
+
+  it("only auto-redirects person a when the session is ready or matched", () => {
+    expect(getInviteReadyRedirectHref("session-1", "pending_b")).toBeNull();
+    expect(getInviteReadyRedirectHref("session-1", "generation_failed")).toBeNull();
+    expect(getInviteReadyRedirectHref("session-1", "expired")).toBeNull();
+    expect(getInviteReadyRedirectHref("session-1", "ready_to_swipe")).toBe(
+      "/plan/session-1",
+    );
+    expect(getInviteReadyRedirectHref("session-1", "matched")).toBe(
+      "/plan/session-1",
+    );
   });
 });

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -27,6 +27,7 @@ export function HookScreen({
 }: HookScreenProps) {
   const [displayName, setDisplayName] = useState(initialDisplayName);
   const [showError, setShowError] = useState(false);
+  const errorId = "invitee-display-name-error";
 
   function handleContinue() {
     const trimmed = displayName.trim();
@@ -83,6 +84,8 @@ export function HookScreen({
                   name="invitee-display-name"
                   type="text"
                   autoComplete="given-name"
+                  aria-invalid={showError}
+                  aria-describedby={showError ? errorId : undefined}
                   value={displayName}
                   onChange={(event) => {
                     setDisplayName(event.target.value);
@@ -100,7 +103,7 @@ export function HookScreen({
                   className="w-full rounded-[1.2rem] border border-muted bg-white/90 px-4 py-3 text-body text-text shadow-sm outline-none transition focus:border-secondary focus:ring-2 focus:ring-secondary/20"
                 />
                 {showError ? (
-                  <p className="text-caption text-error">
+                  <p id={errorId} className="text-caption text-error">
                     Add your name so the shared result feels like both of you.
                   </p>
                 ) : null}

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "./button";
 import { Logo } from "./logo";
 
 type HookScreenProps = {
   readonly creatorName: string;
-  readonly onContinue: () => void;
+  readonly initialDisplayName?: string;
+  readonly onContinue: (displayName: string) => void;
 };
 
 /**
@@ -18,7 +20,26 @@ type HookScreenProps = {
  * that FigmaMake couldn't generate. They sit behind the text at low
  * opacity, making the screen feel warm and designed rather than empty.
  */
-export function HookScreen({ creatorName, onContinue }: HookScreenProps) {
+export function HookScreen({
+  creatorName,
+  initialDisplayName = "",
+  onContinue,
+}: HookScreenProps) {
+  const [displayName, setDisplayName] = useState(initialDisplayName);
+  const [showError, setShowError] = useState(false);
+
+  function handleContinue() {
+    const trimmed = displayName.trim();
+
+    if (!trimmed) {
+      setShowError(true);
+      return;
+    }
+
+    setShowError(false);
+    onContinue(trimmed);
+  }
+
   return (
     <div className="relative flex min-h-dvh flex-col overflow-hidden bg-bg px-6 pb-10 pt-8">
       <div
@@ -42,18 +63,50 @@ export function HookScreen({ creatorName, onContinue }: HookScreenProps) {
 
         <div className="flex flex-1 flex-col justify-center lg:grid lg:grid-cols-[1.1fr_0.9fr] lg:gap-10">
           <section className="max-w-2xl">
-            <p className="text-caption font-semibold uppercase tracking-[0.28em] text-secondary">
-              Person B entry
-            </p>
-            <h1 className="mt-4 text-[clamp(3.25rem,10vw,6rem)] font-semibold leading-[0.92] tracking-[-0.06em] text-text">
+            <h1 className="text-[clamp(3.25rem,10vw,6rem)] font-semibold leading-[0.92] tracking-[-0.06em] text-text">
               <span className="text-primary">{creatorName}</span> wants to plan your first date.
             </h1>
             <p className="mt-5 max-w-xl text-body text-text-secondary">
               This stays lightweight on purpose. Three quick choices, no account wall, and then Dateflow builds the shortlist for both of you.
             </p>
 
-            <div className="mt-8 w-full max-w-sm">
-              <Button onClick={onContinue}>Start in 60 seconds</Button>
+            <div className="mt-8 w-full max-w-sm space-y-3">
+              <div className="space-y-2">
+                <label
+                  htmlFor="invitee-display-name"
+                  className="text-caption font-semibold uppercase tracking-[0.18em] text-secondary"
+                >
+                  Your name
+                </label>
+                <input
+                  id="invitee-display-name"
+                  name="invitee-display-name"
+                  type="text"
+                  autoComplete="given-name"
+                  value={displayName}
+                  onChange={(event) => {
+                    setDisplayName(event.target.value);
+                    if (showError) {
+                      setShowError(false);
+                    }
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      handleContinue();
+                    }
+                  }}
+                  placeholder="What should Dateflow call you?"
+                  className="w-full rounded-[1.2rem] border border-muted bg-white/90 px-4 py-3 text-body text-text shadow-sm outline-none transition focus:border-secondary focus:ring-2 focus:ring-secondary/20"
+                />
+                {showError ? (
+                  <p className="text-caption text-error">
+                    Add your name so the shared result feels like both of you.
+                  </p>
+                ) : null}
+              </div>
+
+              <Button onClick={handleContinue}>Start in 60 seconds</Button>
             </div>
 
             <p className="mt-4 flex items-center gap-1.5 text-caption text-text-secondary">

--- a/web-service/src/components/person-a-flow.tsx
+++ b/web-service/src/components/person-a-flow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "./button";
 import { CategoryIcon } from "./category-icon";
 import { Logo } from "./logo";
@@ -42,6 +43,7 @@ const BUDGETS: { value: BudgetLevel; label: string; symbol: string }[] = [
 ];
 
 export function PersonAFlow() {
+  const router = useRouter();
   const [name, setName] = useState("");
   const [locationLabel, setLocationLabel] = useState("");
   const [location, setLocation] = useState<Location | null>(null);
@@ -203,6 +205,23 @@ export function PersonAFlow() {
       sync.stop();
     };
   }, [createdSession?.id]);
+
+  useEffect(() => {
+    if (!createdSession) {
+      return;
+    }
+
+    const redirectHref = getInviteReadyRedirectHref(
+      createdSession.id,
+      createdSessionStatus,
+    );
+
+    if (!redirectHref) {
+      return;
+    }
+
+    router.push(redirectHref);
+  }, [createdSession, createdSessionStatus, router]);
 
   return (
     <main className="relative min-h-dvh overflow-hidden bg-bg text-text">
@@ -446,6 +465,17 @@ export function getInviteReadySessionStatus(status: string): InviteReadySessionS
   }
 
   return "pending_b";
+}
+
+export function getInviteReadyRedirectHref(
+  sessionId: string,
+  sessionStatus: InviteReadySessionState,
+): string | null {
+  if (sessionStatus === "ready_to_swipe" || sessionStatus === "matched") {
+    return `/plan/${sessionId}`;
+  }
+
+  return null;
 }
 
 function StatCard({

--- a/web-service/src/lib/places-photo-url.ts
+++ b/web-service/src/lib/places-photo-url.ts
@@ -1,0 +1,17 @@
+export function normalizeProxiedPhotoUrl(photoUrl: string): string {
+  if (photoUrl.startsWith("/")) {
+    return photoUrl;
+  }
+
+  try {
+    const parsed = new URL(photoUrl);
+
+    if (parsed.pathname === "/api/places/photos") {
+      return `${parsed.pathname}${parsed.search}`;
+    }
+  } catch {
+    return photoUrl;
+  }
+
+  return photoUrl;
+}

--- a/web-service/src/lib/qstash.ts
+++ b/web-service/src/lib/qstash.ts
@@ -8,6 +8,22 @@ function isUuid(value: string): boolean {
   return UUID_PATTERN.test(value);
 }
 
+function hasWrappedQuotes(value: string | undefined): boolean {
+  return Boolean(value && value.length >= 2 && value.startsWith("\"") && value.endsWith("\""));
+}
+
+function getQstashVerificationUrl(request: Request): string {
+  const forwardedProto = request.headers.get("x-forwarded-proto");
+  const forwardedHost = request.headers.get("x-forwarded-host");
+
+  if (forwardedProto && forwardedHost) {
+    const requestUrl = new URL(request.url);
+    return `${forwardedProto}://${forwardedHost}${requestUrl.pathname}${requestUrl.search}`;
+  }
+
+  return request.url;
+}
+
 export function getQstashReadiness(): {
   readonly ready: boolean;
   readonly missing: readonly string[];
@@ -48,8 +64,17 @@ export async function verifyQstashRequest(request: Request): Promise<boolean> {
   const signature = request.headers.get("Upstash-Signature");
   const currentSigningKey = process.env.QSTASH_CURRENT_SIGNING_KEY;
   const nextSigningKey = process.env.QSTASH_NEXT_SIGNING_KEY;
+  const forwardedProto = request.headers.get("x-forwarded-proto");
+  const forwardedHost = request.headers.get("x-forwarded-host");
 
   if (!signature || !currentSigningKey || !nextSigningKey) {
+    console.warn("[QStash verify] Missing verification inputs", {
+      hasSignature: Boolean(signature),
+      hasCurrentSigningKey: Boolean(currentSigningKey),
+      hasNextSigningKey: Boolean(nextSigningKey),
+      currentSigningKeyWrappedInQuotes: hasWrappedQuotes(currentSigningKey),
+      nextSigningKeyWrappedInQuotes: hasWrappedQuotes(nextSigningKey),
+    });
     return false;
   }
 
@@ -59,16 +84,30 @@ export async function verifyQstashRequest(request: Request): Promise<boolean> {
   });
 
   const body = await request.text();
+  const verificationUrl =
+    forwardedProto && forwardedHost
+      ? `${forwardedProto}://${forwardedHost}${new URL(request.url).pathname}${new URL(request.url).search}`
+      : getQstashVerificationUrl(request);
 
   try {
     return await receiver.verify({
       signature,
       body,
-      url: request.url,
+      url: verificationUrl,
       upstashRegion: request.headers.get("Upstash-Region") ?? undefined,
     });
   } catch (err) {
     if (err instanceof SignatureError) {
+      console.warn("[QStash verify] Signature verification failed", {
+        url: verificationUrl,
+        requestUrl: request.url,
+        forwardedProto,
+        forwardedHost,
+        upstashRegion: request.headers.get("Upstash-Region"),
+        signaturePrefix: signature.slice(0, 16),
+        currentSigningKeyWrappedInQuotes: hasWrappedQuotes(currentSigningKey),
+        nextSigningKeyWrappedInQuotes: hasWrappedQuotes(nextSigningKey),
+      });
       return false;
     }
 

--- a/web-service/src/lib/services/__tests__/places-api-client.test.ts
+++ b/web-service/src/lib/services/__tests__/places-api-client.test.ts
@@ -64,11 +64,11 @@ describe("places-api-client", () => {
   });
 
   describe("buildGooglePlacePhotoUrl", () => {
-    it("builds an internal proxied photo URL from a photo reference", () => {
+    it("builds a relative internal proxied photo URL from a photo reference", () => {
       expect(
         buildGooglePlacePhotoUrl("places/ChIJ_abc123/photos/ref123")
       ).toBe(
-        "https://dateflow.test/api/places/photos?name=places%2FChIJ_abc123%2Fphotos%2Fref123&maxHeightPx=1200"
+        "/api/places/photos?name=places%2FChIJ_abc123%2Fphotos%2Fref123&maxHeightPx=1200"
       );
     });
 
@@ -76,7 +76,7 @@ describe("places-api-client", () => {
       expect(buildGooglePlacePhotoUrl(null)).toBeNull();
     });
 
-    it("falls back to a relative internal URL when app url is not configured", () => {
+    it("returns the same relative internal URL when app url is not configured", () => {
       vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
 
       expect(
@@ -130,7 +130,7 @@ describe("places-api-client", () => {
           "places/ChIJ_abc123/photos/ref123",
         ],
         photoUrls: [
-          "https://dateflow.test/api/places/photos?name=places%2FChIJ_abc123%2Fphotos%2Fref123&maxHeightPx=1200",
+          "/api/places/photos?name=places%2FChIJ_abc123%2Fphotos%2Fref123&maxHeightPx=1200",
         ],
         photoReference: "places/ChIJ_abc123/photos/ref123",
       });
@@ -169,9 +169,9 @@ describe("places-api-client", () => {
         "places/ChIJ_multi123/photos/ref-c",
       ]);
       expect(results[0].photoUrls).toEqual([
-        "https://dateflow.test/api/places/photos?name=places%2FChIJ_multi123%2Fphotos%2Fref-a&maxHeightPx=1200",
-        "https://dateflow.test/api/places/photos?name=places%2FChIJ_multi123%2Fphotos%2Fref-b&maxHeightPx=1200",
-        "https://dateflow.test/api/places/photos?name=places%2FChIJ_multi123%2Fphotos%2Fref-c&maxHeightPx=1200",
+        "/api/places/photos?name=places%2FChIJ_multi123%2Fphotos%2Fref-a&maxHeightPx=1200",
+        "/api/places/photos?name=places%2FChIJ_multi123%2Fphotos%2Fref-b&maxHeightPx=1200",
+        "/api/places/photos?name=places%2FChIJ_multi123%2Fphotos%2Fref-c&maxHeightPx=1200",
       ]);
     });
 
@@ -263,21 +263,48 @@ describe("places-api-client", () => {
         ok: false,
         status: 403,
         statusText: "Forbidden",
-        text: async () => "API key invalid",
+        text: async () => '{"error":{"message":"API key invalid","status":"PERMISSION_DENIED"}}',
       });
 
       await expect(
         searchNearby(location, 2000, ["restaurant"], 3)
-      ).rejects.toThrow("Google Places API error: 403 Forbidden");
+      ).rejects.toThrow(
+        'Google Places API error: 403 Forbidden - {"error":{"message":"API key invalid","status":"PERMISSION_DENIED"}}',
+      );
     });
 
-    it("keeps type filtering consistent when maxPrice is applied", async () => {
+    it("keeps type filtering consistent when maxPrice is applied without sending unsupported request fields", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ places: [] }),
+        json: async () => ({
+          places: [
+            {
+              id: "budget-ok",
+              displayName: { text: "Budget Spot" },
+              formattedAddress: "1 Main St",
+              location: { latitude: 30.0, longitude: -97.0 },
+              types: ["restaurant"],
+              priceLevel: "PRICE_LEVEL_MODERATE",
+              rating: 4.0,
+              userRatingCount: 100,
+              photos: [],
+            },
+            {
+              id: "too-expensive",
+              displayName: { text: "Fancy Spot" },
+              formattedAddress: "2 Main St",
+              location: { latitude: 30.0, longitude: -97.0 },
+              types: ["restaurant"],
+              priceLevel: "PRICE_LEVEL_VERY_EXPENSIVE",
+              rating: 4.8,
+              userRatingCount: 500,
+              photos: [],
+            },
+          ],
+        }),
       });
 
-      await searchNearby(location, 2000, ["restaurant", "bar"], 3);
+      const results = await searchNearby(location, 2000, ["restaurant", "bar"], 3);
 
       const [, request] = mockFetch.mock.calls[0] as [
         string,
@@ -286,8 +313,9 @@ describe("places-api-client", () => {
       const body = JSON.parse(request.body);
 
       expect(body.includedTypes).toEqual(["restaurant", "bar"]);
-      expect(body.maxPriceLevel).toBe(3);
+      expect(body).not.toHaveProperty("maxPriceLevel");
       expect(body).not.toHaveProperty("includedPrimaryTypes");
+      expect(results.map((result) => result.placeId)).toEqual(["budget-ok"]);
     });
   });
 });

--- a/web-service/src/lib/services/__tests__/places-api-client.test.ts
+++ b/web-service/src/lib/services/__tests__/places-api-client.test.ts
@@ -126,8 +126,53 @@ describe("places-api-client", () => {
         priceLevel: 2,
         rating: 4.5,
         reviewCount: 1200,
+        photoReferences: [
+          "places/ChIJ_abc123/photos/ref123",
+        ],
+        photoUrls: [
+          "https://dateflow.test/api/places/photos?name=places%2FChIJ_abc123%2Fphotos%2Fref123&maxHeightPx=1200",
+        ],
         photoReference: "places/ChIJ_abc123/photos/ref123",
       });
+    });
+
+    it("keeps multiple Google photo references in order and maps them to proxied urls", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          places: [
+            {
+              id: "ChIJ_multi123",
+              displayName: { text: "Cafe Bloom" },
+              formattedAddress: "500 Congress Ave, Austin, TX",
+              location: { latitude: 30.2677, longitude: -97.7429 },
+              types: ["cafe", "restaurant"],
+              priceLevel: "PRICE_LEVEL_MODERATE",
+              rating: 4.7,
+              userRatingCount: 803,
+              photos: [
+                { name: "places/ChIJ_multi123/photos/ref-a" },
+                { name: "places/ChIJ_multi123/photos/ref-b" },
+                { name: "places/ChIJ_multi123/photos/ref-c" },
+              ],
+            },
+          ],
+        }),
+      });
+
+      const results = await searchNearby(location, 2000, ["cafe"], 3);
+
+      expect(results[0].photoReference).toBe("places/ChIJ_multi123/photos/ref-a");
+      expect(results[0].photoReferences).toEqual([
+        "places/ChIJ_multi123/photos/ref-a",
+        "places/ChIJ_multi123/photos/ref-b",
+        "places/ChIJ_multi123/photos/ref-c",
+      ]);
+      expect(results[0].photoUrls).toEqual([
+        "https://dateflow.test/api/places/photos?name=places%2FChIJ_multi123%2Fphotos%2Fref-a&maxHeightPx=1200",
+        "https://dateflow.test/api/places/photos?name=places%2FChIJ_multi123%2Fphotos%2Fref-b&maxHeightPx=1200",
+        "https://dateflow.test/api/places/photos?name=places%2FChIJ_multi123%2Fphotos%2Fref-c&maxHeightPx=1200",
+      ]);
     });
 
     it("maps Google price level strings to numeric values", async () => {
@@ -187,6 +232,8 @@ describe("places-api-client", () => {
       expect(results[0].priceLevel).toBe(0);
       expect(results[0].reviewCount).toBe(0);
       expect(results[0].photoReference).toBeNull();
+      expect(results[0].photoReferences).toEqual([]);
+      expect(results[0].photoUrls).toEqual([]);
     });
 
     it("returns empty array when no results", async () => {

--- a/web-service/src/lib/services/__tests__/result-serializer.test.ts
+++ b/web-service/src/lib/services/__tests__/result-serializer.test.ts
@@ -17,6 +17,10 @@ describe("result-serializer", () => {
         lng: -97.74,
         priceLevel: 2,
         rating: 4.6,
+        photoUrls: [
+          "https://example.com/photo.jpg",
+          "https://example.com/photo-2.jpg",
+        ],
         photoUrl: "https://example.com/photo.jpg",
         tags: ["cozy", "patio"],
         round: 3,
@@ -34,5 +38,9 @@ describe("result-serializer", () => {
 
     expect(result.matchedAt).toBe("2026-04-02T18:30:00.000Z");
     expect(result.venue.name).toBe("Cafe Blue");
+    expect(result.venue.photoUrls).toEqual([
+      "https://example.com/photo.jpg",
+      "https://example.com/photo-2.jpg",
+    ]);
   });
 });

--- a/web-service/src/lib/services/__tests__/safety-filter-date-worthiness.test.ts
+++ b/web-service/src/lib/services/__tests__/safety-filter-date-worthiness.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { applySafetyFilter, scoreSafety } from "../safety-filter";
+import type { PlaceCandidate } from "../../types/venue";
+
+function makeCandidate(overrides: Partial<PlaceCandidate> = {}): PlaceCandidate {
+  return {
+    placeId: "candidate-1",
+    name: "Test Venue",
+    address: "123 Main St",
+    location: { lat: 40.75, lng: -74.18, label: "Test Venue" },
+    types: ["restaurant"],
+    priceLevel: 2,
+    rating: 4.6,
+    reviewCount: 240,
+    photoReference: "photo_ref",
+    photoReferences: ["photo_ref"],
+    photoUrls: ["/api/places/photos?name=places%2Ftest%2Fphotos%2Fphoto_ref&maxHeightPx=1200"],
+    ...overrides,
+  };
+}
+
+describe("safety-filter date worthiness", () => {
+  it("rejects generic retail and errand venues even when they are highly rated", () => {
+    const retailCandidate = makeCandidate({
+      placeId: "retail-1",
+      name: "Target",
+      types: ["store", "point_of_interest", "establishment"],
+      rating: 4.7,
+      reviewCount: 2200,
+    });
+
+    const result = applySafetyFilter([retailCandidate]);
+
+    expect(result).toEqual([]);
+    expect(scoreSafety(retailCandidate)).toBe(0);
+  });
+
+  it("keeps true social venues that fit date intent", () => {
+    const socialCandidate = makeCandidate({
+      placeId: "social-1",
+      name: "Museum Date Night",
+      types: ["museum", "tourist_attraction", "point_of_interest"],
+      rating: 4.7,
+      reviewCount: 1500,
+    });
+
+    const result = applySafetyFilter([socialCandidate]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.placeId).toBe("social-1");
+    expect(scoreSafety(socialCandidate)).toBeGreaterThan(0);
+  });
+});

--- a/web-service/src/lib/services/__tests__/safety-filter.test.ts
+++ b/web-service/src/lib/services/__tests__/safety-filter.test.ts
@@ -17,6 +17,8 @@ function makeCandidate(overrides: Partial<PlaceCandidate> = {}): PlaceCandidate 
     rating: 4.5,
     reviewCount: 200,
     photoReference: "photo_ref",
+    photoReferences: ["photo_ref"],
+    photoUrls: ["/api/places/photos?name=places%2Ftest%2Fphotos%2Fphoto_ref&maxHeightPx=1200"],
     ...overrides,
   };
 }
@@ -69,6 +71,20 @@ describe("safety-filter", () => {
       expect(result).toHaveLength(0);
     });
 
+    it("rejects grocery and supermarket venues even when they are highly rated", () => {
+      const groceryStore = makeCandidate({
+        placeId: "grocery_1",
+        name: "ShopRite",
+        types: ["grocery_store", "supermarket", "food", "store"],
+        rating: 4.7,
+        reviewCount: 1800,
+      });
+
+      const result = applySafetyFilter([groceryStore]);
+
+      expect(result).toHaveLength(0);
+    });
+
     it("keeps safe venues and removes unsafe ones from the same list", () => {
       const good = makeCandidate({ placeId: "good_1" });
       const bad = makeCandidate({ placeId: "bad_1", rating: 1.0 });
@@ -108,6 +124,17 @@ describe("safety-filter", () => {
       const score = scoreSafety(unsafe);
 
       expect(score).toBe(0);
+    });
+
+    it("returns 0 for grocery and supermarket venues", () => {
+      const groceryStore = makeCandidate({
+        name: "ShopRite",
+        types: ["grocery_store", "supermarket", "food", "store"],
+        rating: 4.7,
+        reviewCount: 1800,
+      });
+
+      expect(scoreSafety(groceryStore)).toBe(0);
     });
 
     it("returns a higher score for more reviews", () => {

--- a/web-service/src/lib/services/__tests__/session-service.test.ts
+++ b/web-service/src/lib/services/__tests__/session-service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   createSession,
   getSession,
+  setInviteeDisplayName,
   validateSessionForJoin,
   expireStaleSessions,
 } from "../session-service";
@@ -32,12 +33,22 @@ const mockQuerySelect = vi.fn(() => ({ eq: mockEq }));
 const mockLte = vi.fn();
 const mockNeq = vi.fn(() => ({ neq: mockNeq, lte: mockLte }));
 const mockUpdate = vi.fn(() => ({ neq: mockNeq }));
+const mockUpdateInviteeIdEq = vi.fn();
+const mockUpdateWithEq = vi.fn(() => ({ eq: mockUpdateInviteeIdEq }));
 
 // from() returns all three chains
 const mockFrom = vi.fn(() => ({
   insert: mockInsert,
   select: mockQuerySelect,
-  update: mockUpdate,
+  update: (...args: unknown[]) => {
+    const payload = args[0] as Record<string, unknown>;
+
+    if ("invitee_display_name" in payload) {
+      return mockUpdateWithEq(...args);
+    }
+
+    return mockUpdate(...args);
+  },
 }));
 
 vi.mock("../../supabase-server", () => ({
@@ -49,6 +60,7 @@ const fakeRow: SessionRow = {
   id: "fake-uuid-1234",
   status: "pending_b",
   creator_display_name: "Alex",
+  invitee_display_name: null,
   created_at: "2026-03-27T12:00:00Z",
   expires_at: "2026-03-29T12:00:00Z",
   matched_venue_id: null,
@@ -119,6 +131,23 @@ describe("createSession", () => {
     });
 
     await expect(createSession("Alex")).rejects.toThrow("DB connection lost");
+  });
+});
+
+describe("setInviteeDisplayName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateInviteeIdEq.mockResolvedValue({ error: null });
+  });
+
+  it("stores a trimmed invitee display name on the session", async () => {
+    await setInviteeDisplayName("fake-uuid-1234", "  Jordan  ");
+
+    expect(mockFrom).toHaveBeenCalledWith("sessions");
+    expect(mockUpdateWithEq).toHaveBeenCalledWith({
+      invitee_display_name: "Jordan",
+    });
+    expect(mockUpdateInviteeIdEq).toHaveBeenCalledWith("id", "fake-uuid-1234");
   });
 });
 

--- a/web-service/src/lib/services/__tests__/venue-cache.test.ts
+++ b/web-service/src/lib/services/__tests__/venue-cache.test.ts
@@ -14,6 +14,23 @@ describe("VenueCache", () => {
   let cache: VenueCache;
   let mockRedisClient: { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> };
 
+  function makeCandidate(overrides: Partial<PlaceCandidate> = {}): PlaceCandidate {
+    return {
+      placeId: "place1",
+      name: "Cafe",
+      address: "456 Oak Ave",
+      location: { lat: 30.2672, lng: -97.7431, label: "Austin" },
+      types: ["cafe"],
+      priceLevel: 1,
+      rating: 4.0,
+      reviewCount: 50,
+      photoReference: null,
+      photoReferences: [],
+      photoUrls: [],
+      ...overrides,
+    };
+  }
+
   beforeEach(() => {
     // Reset mocks before each test
     vi.clearAllMocks();
@@ -86,17 +103,16 @@ describe("VenueCache", () => {
     it("stores candidates and retrieves them", async () => {
       const key = "test:venue:cache:key";
       const candidates: PlaceCandidate[] = [
-        {
-          placeId: "place1",
+        makeCandidate({
           name: "Restaurant A",
           address: "123 Main St",
-          location: { lat: 30.2672, lng: -97.7431, label: "Austin" },
           types: ["restaurant"],
           priceLevel: 2,
           rating: 4.5,
           reviewCount: 150,
           photoReference: "photo123",
-        },
+          photoReferences: ["photo123"],
+        }),
       ];
       const ttl = 3600;
 
@@ -126,21 +142,20 @@ describe("VenueCache", () => {
 
     it("parses JSON candidates from Redis", async () => {
       const key = "test:key";
-      const candidates: PlaceCandidate[] = [
-        {
-          placeId: "place1",
-          name: "Cafe",
-          address: "456 Oak Ave",
-          location: { lat: 30.2672, lng: -97.7431, label: "Austin" },
-          types: ["cafe"],
-          priceLevel: 1,
-          rating: 4.0,
-          reviewCount: 50,
-          photoReference: null,
-        },
-      ];
+      const candidates: PlaceCandidate[] = [makeCandidate()];
 
       mockRedisClient.get.mockResolvedValue(JSON.stringify(candidates));
+
+      const retrieved = await cache.get(key);
+
+      expect(retrieved).toEqual(candidates);
+    });
+
+    it("returns already-materialized cached arrays without reparsing", async () => {
+      const key = "test:key";
+      const candidates: PlaceCandidate[] = [makeCandidate()];
+
+      mockRedisClient.get.mockResolvedValue(candidates);
 
       const retrieved = await cache.get(key);
 

--- a/web-service/src/lib/services/__tests__/venue-generation-category-intent.test.ts
+++ b/web-service/src/lib/services/__tests__/venue-generation-category-intent.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Preference } from "../../types/preference";
+import type { PlaceCandidate } from "../../types/venue";
+
+const mockQueryOrderPosition = vi.fn();
+const mockQueryOrderRound = vi.fn(() => ({
+  order: mockQueryOrderPosition,
+}));
+const mockQueryEq = vi.fn(() => ({
+  order: mockQueryOrderRound,
+}));
+const mockQuerySelect = vi.fn(() => ({
+  eq: mockQueryEq,
+}));
+
+const mockInsertSelectSingle = vi.fn();
+const mockInsertSelect = vi.fn(() => ({ single: mockInsertSelectSingle }));
+const mockInsert = vi.fn(() => ({ select: mockInsertSelect }));
+const mockUpsert = vi.fn();
+
+const mockUpdateSelect = vi.fn();
+const mockUpdateIn = vi.fn(() => ({ select: mockUpdateSelect }));
+const mockUpdateEqStatus = vi.fn(() => ({ select: mockUpdateSelect }));
+const mockUpdateEqId = vi.fn(() => ({
+  eq: mockUpdateEqStatus,
+  in: mockUpdateIn,
+}));
+const mockUpdate = vi.fn(() => ({ eq: mockUpdateEqId }));
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "sessions") {
+    return { update: mockUpdate };
+  }
+
+  if (table === "session_candidate_pools" || table === "venue_generation_batches") {
+    return { insert: mockInsert };
+  }
+
+  return {
+    select: mockQuerySelect,
+    upsert: mockUpsert,
+  };
+});
+
+vi.mock("../../supabase-server", () => ({
+  getSupabaseServerClient: () => ({ from: mockFrom }),
+}));
+
+const mockGetBothPreferences = vi.fn();
+vi.mock("../preference-service", () => ({
+  getBothPreferences: (...args: unknown[]) => mockGetBothPreferences(...args),
+}));
+
+const mockCalculateMidpoint = vi.fn();
+vi.mock("../midpoint-calculator", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../midpoint-calculator")>();
+  return {
+    ...actual,
+    calculateMidpoint: (...args: unknown[]) => mockCalculateMidpoint(...args),
+  };
+});
+
+const mockSearchNearbyWithCache = vi.fn();
+vi.mock("../places-api-cached", () => ({
+  searchNearbyWithCache: (...args: unknown[]) => mockSearchNearbyWithCache(...args),
+}));
+
+const mockScoreAndCurate = vi.fn();
+vi.mock("../ai-curation-service", () => ({
+  scoreAndCurate: (...args: unknown[]) => mockScoreAndCurate(...args),
+}));
+
+const preferences: readonly [Preference, Preference] = [
+  {
+    id: "pref-a",
+    sessionId: "session-1",
+    role: "a",
+    location: { lat: 30.28, lng: -97.74, label: "North" },
+    budget: "MODERATE",
+    categories: ["RESTAURANT", "BAR"],
+    createdAt: new Date("2026-04-01T10:00:00Z"),
+  },
+  {
+    id: "pref-b",
+    sessionId: "session-1",
+    role: "b",
+    location: { lat: 30.25, lng: -97.75, label: "South" },
+    budget: "MODERATE",
+    categories: ["RESTAURANT", "BAR"],
+    createdAt: new Date("2026-04-01T10:01:00Z"),
+  },
+];
+
+const originalGooglePlacesApiKey = process.env.GOOGLE_PLACES_API_KEY;
+const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+function makeCandidate(overrides: Partial<PlaceCandidate> = {}): PlaceCandidate {
+  return {
+    placeId: "place-1",
+    name: "Default Venue",
+    address: "1 Main St",
+    location: { lat: 30.26, lng: -97.74, label: "Venue" },
+    types: ["restaurant"],
+    priceLevel: 2,
+    rating: 4.6,
+    reviewCount: 250,
+    photoReference: null,
+    photoReferences: [],
+    photoUrls: [],
+    category: "RESTAURANT",
+    tags: [],
+    score: {
+      categoryOverlap: 1,
+      distanceToMidpoint: 0.9,
+      firstDateSuitability: 0.85,
+      qualitySignal: 0.9,
+      timeOfDayFit: 0.8,
+      composite: 0.89,
+    },
+    ...overrides,
+  } as PlaceCandidate & {
+    readonly category: "RESTAURANT" | "BAR" | "EVENT" | "ACTIVITY";
+    readonly tags: readonly string[];
+    readonly score: {
+      readonly categoryOverlap: number;
+      readonly distanceToMidpoint: number;
+      readonly firstDateSuitability: number;
+      readonly qualitySignal: number;
+      readonly timeOfDayFit: number;
+      readonly composite: number;
+    };
+  };
+}
+
+describe("generateVenues category intent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GOOGLE_PLACES_API_KEY = "test-api-key";
+    process.env.NEXT_PUBLIC_APP_URL = "https://dateflow.test";
+    mockGetBothPreferences.mockResolvedValue(preferences);
+    mockCalculateMidpoint.mockReturnValue({
+      lat: 30.265,
+      lng: -97.745,
+      label: "Midpoint",
+    });
+
+    const restaurantCandidate = makeCandidate({
+      placeId: "restaurant-1",
+      name: "Good Bistro",
+      types: ["restaurant", "food", "point_of_interest", "establishment"],
+    });
+    const spilloverMuseum = makeCandidate({
+      placeId: "museum-1",
+      name: "Spillover Museum",
+      types: ["museum", "point_of_interest", "establishment"],
+      category: "ACTIVITY",
+    });
+
+    mockSearchNearbyWithCache.mockResolvedValue([restaurantCandidate, spilloverMuseum]);
+    mockScoreAndCurate
+      .mockResolvedValueOnce([restaurantCandidate])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    mockInsertSelectSingle
+      .mockResolvedValueOnce({
+        data: { id: "pool-1" },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { id: "batch-1" },
+        error: null,
+      });
+    mockUpsert.mockResolvedValue({ error: null });
+    mockUpdateSelect.mockResolvedValue({ data: [{ id: "session-1" }], error: null });
+    mockQueryOrderPosition.mockResolvedValue({ data: [], error: null });
+  });
+
+  afterEach(() => {
+    process.env.GOOGLE_PLACES_API_KEY = originalGooglePlacesApiKey;
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+  });
+
+  it("filters out spillover venues that do not match the pair's requested categories", async () => {
+    const { generateVenues } = await import("../venue-generation-service");
+
+    await generateVenues("session-1");
+
+    const candidatePoolRows = mockUpsert.mock.calls[0][0];
+    expect(candidatePoolRows).toHaveLength(1);
+    expect(candidatePoolRows[0].place_id).toBe("restaurant-1");
+
+    expect(mockScoreAndCurate).toHaveBeenNthCalledWith(
+      1,
+      [
+        expect.objectContaining({
+          placeId: "restaurant-1",
+        }),
+      ],
+      preferences,
+      1,
+      { lat: 30.265, lng: -97.745, label: "Midpoint" },
+    );
+  });
+});

--- a/web-service/src/lib/services/__tests__/venue-generation-service.test.ts
+++ b/web-service/src/lib/services/__tests__/venue-generation-service.test.ts
@@ -127,8 +127,8 @@ function makeCuratedVenue(index: number): CuratedVenueCandidate {
     photoUrls:
       index % 2 === 0
         ? [
-            `https://dateflow.test/api/places/photos?name=places%2Fplace-${index}%2Fphotos%2Fphoto-${index}&maxHeightPx=1200`,
-            `https://dateflow.test/api/places/photos?name=places%2Fplace-${index}%2Fphotos%2Fphoto-${index}-b&maxHeightPx=1200`,
+            `/api/places/photos?name=places%2Fplace-${index}%2Fphotos%2Fphoto-${index}&maxHeightPx=1200`,
+            `/api/places/photos?name=places%2Fplace-${index}%2Fphotos%2Fphoto-${index}-b&maxHeightPx=1200`,
           ]
         : [],
     tags: ["unscored"],
@@ -251,11 +251,11 @@ describe("generateVenues", () => {
     expect(candidatePoolRows[0].photo_url).toBeNull();
     expect(candidatePoolRows[0].photo_urls).toEqual([]);
     expect(candidatePoolRows[1].photo_url).toBe(
-      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200"
+      "/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200"
     );
     expect(candidatePoolRows[1].photo_urls).toEqual([
-      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200",
-      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2-b&maxHeightPx=1200",
+      "/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200",
+      "/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2-b&maxHeightPx=1200",
     ]);
 
     const insertedRows = mockUpsert.mock.calls[1][0];
@@ -267,11 +267,11 @@ describe("generateVenues", () => {
     expect(insertedRows[0].photo_url).toBeNull();
     expect(insertedRows[0].photo_urls).toEqual([]);
     expect(insertedRows[1].photo_url).toBe(
-      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200"
+      "/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200"
     );
     expect(insertedRows[1].photo_urls).toEqual([
-      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200",
-      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2-b&maxHeightPx=1200",
+      "/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200",
+      "/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2-b&maxHeightPx=1200",
     ]);
     expect(insertedRows[4].round).toBe(2);
     expect(insertedRows[8].round).toBe(3);

--- a/web-service/src/lib/services/__tests__/venue-generation-service.test.ts
+++ b/web-service/src/lib/services/__tests__/venue-generation-service.test.ts
@@ -117,6 +117,20 @@ function makeCuratedVenue(index: number): CuratedVenueCandidate {
     reviewCount: 200 + index,
     photoReference:
       index % 2 === 0 ? `places/place-${index}/photos/photo-${index}` : null,
+    photoReferences:
+      index % 2 === 0
+        ? [
+            `places/place-${index}/photos/photo-${index}`,
+            `places/place-${index}/photos/photo-${index}-b`,
+          ]
+        : [],
+    photoUrls:
+      index % 2 === 0
+        ? [
+            `https://dateflow.test/api/places/photos?name=places%2Fplace-${index}%2Fphotos%2Fphoto-${index}&maxHeightPx=1200`,
+            `https://dateflow.test/api/places/photos?name=places%2Fplace-${index}%2Fphotos%2Fphoto-${index}-b&maxHeightPx=1200`,
+          ]
+        : [],
     tags: ["unscored"],
     score: {
       categoryOverlap: 1,
@@ -144,6 +158,7 @@ function makeVenueRow(index: number): VenueRow {
     lng: -97.74,
     price_level: 1,
     rating: 4.5,
+    photo_urls: null,
     photo_url: null,
     tags: ["unscored"],
     round,
@@ -234,9 +249,14 @@ describe("generateVenues", () => {
     expect(candidatePoolRows[0].pool_id).toBe("pool-1");
     expect(candidatePoolRows[0].source_rank).toBe(1);
     expect(candidatePoolRows[0].photo_url).toBeNull();
+    expect(candidatePoolRows[0].photo_urls).toEqual([]);
     expect(candidatePoolRows[1].photo_url).toBe(
       "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200"
     );
+    expect(candidatePoolRows[1].photo_urls).toEqual([
+      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200",
+      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2-b&maxHeightPx=1200",
+    ]);
 
     const insertedRows = mockUpsert.mock.calls[1][0];
     expect(insertedRows).toHaveLength(12);
@@ -245,9 +265,14 @@ describe("generateVenues", () => {
     expect(insertedRows[0].generation_batch_id).toBe("batch-1");
     expect(insertedRows[0].surfaced_cycle).toBe(1);
     expect(insertedRows[0].photo_url).toBeNull();
+    expect(insertedRows[0].photo_urls).toEqual([]);
     expect(insertedRows[1].photo_url).toBe(
       "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200"
     );
+    expect(insertedRows[1].photo_urls).toEqual([
+      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2&maxHeightPx=1200",
+      "https://dateflow.test/api/places/photos?name=places%2Fplace-2%2Fphotos%2Fphoto-2-b&maxHeightPx=1200",
+    ]);
     expect(insertedRows[4].round).toBe(2);
     expect(insertedRows[8].round).toBe(3);
 

--- a/web-service/src/lib/services/__tests__/venue-retry-runtime.test.ts
+++ b/web-service/src/lib/services/__tests__/venue-retry-runtime.test.ts
@@ -143,7 +143,12 @@ describe("rerankStoredCandidates", () => {
     expect(insertedRows[0].photo_url).toBe(
       "https://example.com/place-13.jpg",
     );
+    expect(insertedRows[0].photo_urls).toEqual([
+      "https://example.com/place-13.jpg",
+      "https://example.com/place-13-b.jpg",
+    ]);
     expect(insertedRows[1].photo_url).toBeNull();
+    expect(insertedRows[1].photo_urls).toEqual([]);
 
     expect(result).toEqual({
       strategy: "pool_rerank",
@@ -205,6 +210,13 @@ function makePoolItemRow(index: number): SessionCandidatePoolItemRow {
     lng: -97.74,
     price_level: 2,
     rating: 4.5,
+    photo_urls:
+      index % 2 === 1
+        ? [
+            `https://example.com/place-${index}.jpg`,
+            `https://example.com/place-${index}-b.jpg`,
+          ]
+        : null,
     photo_url: index % 2 === 1 ? `https://example.com/place-${index}.jpg` : null,
     raw_types: ["restaurant"],
     raw_tags: [],

--- a/web-service/src/lib/services/ai-curation-service.ts
+++ b/web-service/src/lib/services/ai-curation-service.ts
@@ -63,6 +63,29 @@ type AiProviderCallResult = {
   };
 };
 
+function summarizeAiAdjustments(
+  finalists: readonly CuratedVenueCandidate[],
+  adjustments: readonly AiVenueAdjustment[],
+) {
+  const finalistByPlaceId = new Map(
+    finalists.map((candidate) => [candidate.placeId, candidate]),
+  );
+
+  return adjustments.map((adjustment) => {
+    const finalist = finalistByPlaceId.get(adjustment.placeId);
+
+    return {
+      placeId: adjustment.placeId,
+      name: finalist?.name ?? null,
+      firstDateSuitabilityBefore:
+        finalist?.score.firstDateSuitability ?? null,
+      firstDateSuitabilityAfter: adjustment.firstDateSuitability,
+      rerankAdjustment: adjustment.rerankAdjustment,
+      tags: adjustment.tags,
+    };
+  });
+}
+
 function roundBonus(category: Category, round: number): number {
   if (round === 2 && (category === "ACTIVITY" || category === "EVENT")) {
     return 0.15;
@@ -516,7 +539,9 @@ export async function scoreAndCurate(
         model: GEMINI_MODEL,
         promptVersion: aiConfig.promptVersion,
         latencyMs: Date.now() - startedAt,
+        finalistCount: finalists.length,
         usage: result.usage,
+        adjustments: summarizeAiAdjustments(finalists, result.adjustments),
       });
 
       return mergeAiAdjustments(deterministicRanking, result.adjustments);

--- a/web-service/src/lib/services/demo-venue-service.ts
+++ b/web-service/src/lib/services/demo-venue-service.ts
@@ -123,6 +123,7 @@ export async function generateDemoVenues(
       lng: midpoint.lng - lngOffset,
       price_level: seed.priceLevel,
       rating: seed.rating,
+      photo_urls: [],
       photo_url: null,
       tags: [...seed.tags, `round ${round}`],
       round,

--- a/web-service/src/lib/services/places-api-cached.ts
+++ b/web-service/src/lib/services/places-api-cached.ts
@@ -48,8 +48,24 @@ export async function searchNearbyWithCache(
     try {
       const cached = await cache.get(cacheKey);
       if (cached) {
+        console.info("[searchNearbyWithCache] cache hit", {
+          cacheKey,
+          candidateCount: cached.length,
+          locationLabel: location.label,
+          radius,
+          categories,
+          maxPrice,
+        });
         return cached;
       }
+
+      console.info("[searchNearbyWithCache] cache miss", {
+        cacheKey,
+        locationLabel: location.label,
+        radius,
+        categories,
+        maxPrice,
+      });
     } catch (err) {
       // Cache read failed — log and fall through to API call
       console.error("[searchNearbyWithCache] Cache read failed, calling API:", err);
@@ -60,12 +76,30 @@ export async function searchNearbyWithCache(
   const googleTypes = categoriesToGoogleTypes(categories);
 
   // Cache miss or error — call Google Places
+  console.info("[searchNearbyWithCache] fetching from Google Places", {
+    cacheKey,
+    googleTypes,
+    radius,
+    maxPrice,
+    locationLabel: location.label,
+  });
   const candidates = await searchNearby(location, radius, googleTypes, maxPrice);
+
+  console.info("[searchNearbyWithCache] Google Places returned candidates", {
+    cacheKey,
+    candidateCount: candidates.length,
+  });
 
   // Write to cache (fire-and-forget — don't block on this)
   if (cache && cacheKey) {
     cache.set(cacheKey, candidates, CACHE_TTL_SECONDS).catch((err) => {
       console.error("[searchNearbyWithCache] Cache write failed:", err);
+    });
+
+    console.info("[searchNearbyWithCache] scheduled cache write", {
+      cacheKey,
+      candidateCount: candidates.length,
+      ttlSeconds: CACHE_TTL_SECONDS,
     });
   }
 

--- a/web-service/src/lib/services/places-api-client.ts
+++ b/web-service/src/lib/services/places-api-client.ts
@@ -59,6 +59,14 @@ export function buildGooglePlacePhotoUrl(
   return `${appUrl}${PLACES_PHOTO_ROUTE}?${photoQuery}`;
 }
 
+export function buildGooglePlacePhotoUrls(
+  photoReferences: readonly string[],
+): readonly string[] {
+  return photoReferences
+    .map((photoReference) => buildGooglePlacePhotoUrl(photoReference))
+    .filter((photoUrl): photoUrl is string => photoUrl !== null);
+}
+
 // ---------------------------------------------------------------------------
 // Google price level string → numeric mapping
 // ---------------------------------------------------------------------------
@@ -247,19 +255,25 @@ export async function searchNearby(
   const data = await response.json();
   const places: readonly GooglePlace[] = data.places ?? [];
 
-  return places.map((place) => ({
-    placeId: place.id,
-    name: place.displayName.text,
-    address: place.formattedAddress,
-    location: {
-      lat: place.location.latitude,
-      lng: place.location.longitude,
-      label: place.displayName.text,
-    },
-    types: place.types,
-    priceLevel: parsePriceLevel(place.priceLevel),
-    rating: place.rating ?? 0,
-    reviewCount: place.userRatingCount ?? 0,
-    photoReference: place.photos?.[0]?.name ?? null,
-  }));
+  return places.map((place) => {
+    const photoReferences = (place.photos ?? []).map((photo) => photo.name);
+
+    return {
+      placeId: place.id,
+      name: place.displayName.text,
+      address: place.formattedAddress,
+      location: {
+        lat: place.location.latitude,
+        lng: place.location.longitude,
+        label: place.displayName.text,
+      },
+      types: place.types,
+      priceLevel: parsePriceLevel(place.priceLevel),
+      rating: place.rating ?? 0,
+      reviewCount: place.userRatingCount ?? 0,
+      photoReferences,
+      photoReference: photoReferences[0] ?? null,
+      photoUrls: buildGooglePlacePhotoUrls(photoReferences),
+    };
+  });
 }

--- a/web-service/src/lib/services/places-api-client.ts
+++ b/web-service/src/lib/services/places-api-client.ts
@@ -50,13 +50,7 @@ export function buildGooglePlacePhotoUrl(
     ? photoReference
     : `places/${photoReference}`;
   const photoQuery = `name=${encodeURIComponent(photoPath)}&maxHeightPx=${DEFAULT_PHOTO_MAX_HEIGHT_PX}`;
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "");
-
-  if (!appUrl) {
-    return `${PLACES_PHOTO_ROUTE}?${photoQuery}`;
-  }
-
-  return `${appUrl}${PLACES_PHOTO_ROUTE}?${photoQuery}`;
+  return `${PLACES_PHOTO_ROUTE}?${photoQuery}`;
 }
 
 export function buildGooglePlacePhotoUrls(
@@ -232,9 +226,6 @@ export async function searchNearby(
         radius,
       },
     },
-    ...(maxPrice > 0 && {
-      maxPriceLevel: maxPrice,
-    }),
   };
 
   const response = await fetch(PLACES_API_URL, {
@@ -249,14 +240,30 @@ export async function searchNearby(
 
   if (!response.ok) {
     const statusText = response.statusText;
-    throw new Error(`Google Places API error: ${response.status} ${statusText}`);
+    const errorBody = await response.text();
+    const trimmedErrorBody = errorBody.trim();
+
+    if (trimmedErrorBody) {
+      console.error("[Google Places] searchNearby failed", {
+        status: response.status,
+        statusText,
+        body: trimmedErrorBody,
+      });
+    }
+
+    throw new Error(
+      trimmedErrorBody
+        ? `Google Places API error: ${response.status} ${statusText} - ${trimmedErrorBody}`
+        : `Google Places API error: ${response.status} ${statusText}`,
+    );
   }
 
   const data = await response.json();
   const places: readonly GooglePlace[] = data.places ?? [];
 
-  return places.map((place) => {
+  const candidates = places.map((place) => {
     const photoReferences = (place.photos ?? []).map((photo) => photo.name);
+    const priceLevel = parsePriceLevel(place.priceLevel);
 
     return {
       placeId: place.id,
@@ -268,7 +275,7 @@ export async function searchNearby(
         label: place.displayName.text,
       },
       types: place.types,
-      priceLevel: parsePriceLevel(place.priceLevel),
+      priceLevel,
       rating: place.rating ?? 0,
       reviewCount: place.userRatingCount ?? 0,
       photoReferences,
@@ -276,4 +283,13 @@ export async function searchNearby(
       photoUrls: buildGooglePlacePhotoUrls(photoReferences),
     };
   });
+
+  if (maxPrice <= 0) {
+    return candidates;
+  }
+
+  return candidates.filter(
+    (candidate) =>
+      candidate.priceLevel === 0 || candidate.priceLevel <= maxPrice,
+  );
 }

--- a/web-service/src/lib/services/result-serializer.ts
+++ b/web-service/src/lib/services/result-serializer.ts
@@ -12,6 +12,7 @@ export type SerializedVenue = {
   readonly lng: number;
   readonly priceLevel: number;
   readonly rating: number;
+  readonly photoUrls: readonly string[];
   readonly photoUrl: string | null;
   readonly tags: readonly string[];
   readonly round: number;
@@ -28,9 +29,28 @@ export type SerializedMatchResult = {
 export function serializeMatchResult(
   matchResult: MatchResult,
 ): SerializedMatchResult {
+  const { venue } = matchResult;
+
   return {
     sessionId: matchResult.sessionId,
-    venue: matchResult.venue,
+    venue: {
+      id: venue.id,
+      sessionId: venue.sessionId,
+      placeId: venue.placeId,
+      name: venue.name,
+      category: venue.category,
+      address: venue.address,
+      lat: venue.lat,
+      lng: venue.lng,
+      priceLevel: venue.priceLevel,
+      rating: venue.rating,
+      photoUrls: [...venue.photoUrls],
+      photoUrl: venue.photoUrl,
+      tags: [...venue.tags],
+      round: venue.round,
+      position: venue.position,
+      score: venue.score,
+    },
     matchedAt: matchResult.matchedAt.toISOString(),
   };
 }

--- a/web-service/src/lib/services/safety-filter.ts
+++ b/web-service/src/lib/services/safety-filter.ts
@@ -1,4 +1,6 @@
+import type { Category } from "../types/preference";
 import type { PlaceCandidate } from "../types/venue";
+import { mapGoogleTypeToCategory } from "./places-api-client";
 
 // ---------------------------------------------------------------------------
 // Hard rules — any venue with these types is immediately rejected
@@ -36,6 +38,28 @@ const UNSAFE_TYPES = new Set([
   "plumber",
   "hardware_store",
   "convenience_store",
+  "grocery_store",
+  "supermarket",
+]);
+
+const DATE_WORTHY_TYPES = new Set([
+  "restaurant",
+  "cafe",
+  "bakery",
+  "bar",
+  "night_club",
+  "movie_theater",
+  "performing_arts_theater",
+  "stadium",
+  "bowling_alley",
+  "amusement_park",
+  "aquarium",
+  "art_gallery",
+  "museum",
+  "park",
+  "spa",
+  "tourist_attraction",
+  "zoo",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -66,6 +90,10 @@ function hasUnsafeType(types: readonly string[]): boolean {
   return types.some((type) => UNSAFE_TYPES.has(type));
 }
 
+function hasDateWorthyType(types: readonly string[]): boolean {
+  return types.some((type) => DATE_WORTHY_TYPES.has(type));
+}
+
 /**
  * Returns true if the venue passes ALL hard safety rules.
  * A venue must clear every gate to be considered safe:
@@ -73,8 +101,24 @@ function hasUnsafeType(types: readonly string[]): boolean {
  *   2. Rating ≥ 3.5
  *   3. At least 50 reviews (social proof that it's a real, visited place)
  */
-function passesHardRules(candidate: PlaceCandidate): boolean {
+function matchesRequestedCategories(
+  candidate: PlaceCandidate,
+  requestedCategories?: readonly Category[],
+): boolean {
+  if (!requestedCategories || requestedCategories.length === 0) {
+    return true;
+  }
+
+  return requestedCategories.includes(mapGoogleTypeToCategory(candidate.types));
+}
+
+function passesHardRules(
+  candidate: PlaceCandidate,
+  requestedCategories?: readonly Category[],
+): boolean {
   if (hasUnsafeType(candidate.types)) return false;
+  if (!hasDateWorthyType(candidate.types)) return false;
+  if (!matchesRequestedCategories(candidate, requestedCategories)) return false;
   if (candidate.rating < MIN_RATING) return false;
   if (candidate.reviewCount < MIN_REVIEW_COUNT) return false;
   return true;
@@ -96,9 +140,12 @@ function passesHardRules(candidate: PlaceCandidate): boolean {
  * @returns           Only the candidates that pass all safety rules
  */
 export function applySafetyFilter(
-  candidates: readonly PlaceCandidate[]
+  candidates: readonly PlaceCandidate[],
+  requestedCategories?: readonly Category[],
 ): readonly PlaceCandidate[] {
-  return candidates.filter(passesHardRules);
+  return candidates.filter((candidate) =>
+    passesHardRules(candidate, requestedCategories),
+  );
 }
 
 /**

--- a/web-service/src/lib/services/session-service.ts
+++ b/web-service/src/lib/services/session-service.ts
@@ -32,6 +32,10 @@ function validateDisplayName(raw: string): string {
   return trimmed;
 }
 
+export function sanitizeDisplayName(raw: string): string {
+  return validateDisplayName(raw);
+}
+
 /**
  * Creates a new planning session.
  *
@@ -56,6 +60,23 @@ export async function createSession(
   }
 
   return toSession(data);
+}
+
+export async function setInviteeDisplayName(
+  sessionId: string,
+  inviteeDisplayName: string,
+): Promise<void> {
+  const name = validateDisplayName(inviteeDisplayName);
+  const supabase = getSupabaseServerClient();
+
+  const { error } = await supabase
+    .from("sessions")
+    .update({ invitee_display_name: name })
+    .eq("id", sessionId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
 }
 
 /**

--- a/web-service/src/lib/services/venue-cache.ts
+++ b/web-service/src/lib/services/venue-cache.ts
@@ -69,15 +69,23 @@ export class VenueCache {
         return null;
       }
 
-      if (typeof cached !== "string") {
-        console.warn(`[VenueCache.get] Non-string cached value for key "${key}"`, {
+      if (typeof cached === "string") {
+        return JSON.parse(cached) as readonly PlaceCandidate[];
+      }
+
+      if (Array.isArray(cached)) {
+        console.warn(`[VenueCache.get] Returning non-string cached value for key "${key}"`, {
           valueType: typeof cached,
           preview: this.getValuePreview(cached),
         });
+        return cached as readonly PlaceCandidate[];
       }
 
-      // Redis returns a string; parse it back to PlaceCandidate[]
-      return JSON.parse(cached as string) as readonly PlaceCandidate[];
+      console.warn(`[VenueCache.get] Unexpected cached value shape for key "${key}"`, {
+        valueType: typeof cached,
+        preview: this.getValuePreview(cached),
+      });
+      return null;
     } catch (err) {
       // Log errors but don't crash — cache misses are acceptable.
       // If Redis is down, we'll just call Google Places directly.

--- a/web-service/src/lib/services/venue-cache.ts
+++ b/web-service/src/lib/services/venue-cache.ts
@@ -16,6 +16,18 @@ import type { Location } from "../types/preference";
 export class VenueCache {
   private redis = getRedisClient();
 
+  private getValuePreview(value: unknown): string {
+    if (typeof value === "string") {
+      return value.slice(0, 160);
+    }
+
+    try {
+      return JSON.stringify(value).slice(0, 160);
+    } catch {
+      return String(value).slice(0, 160);
+    }
+  }
+
   /**
    * Builds a cache key from search parameters.
    *
@@ -57,12 +69,28 @@ export class VenueCache {
         return null;
       }
 
+      if (typeof cached !== "string") {
+        console.warn(`[VenueCache.get] Non-string cached value for key "${key}"`, {
+          valueType: typeof cached,
+          preview: this.getValuePreview(cached),
+        });
+      }
+
       // Redis returns a string; parse it back to PlaceCandidate[]
       return JSON.parse(cached as string) as readonly PlaceCandidate[];
     } catch (err) {
       // Log errors but don't crash — cache misses are acceptable.
       // If Redis is down, we'll just call Google Places directly.
-      console.error(`[VenueCache.get] Failed to retrieve key "${key}":`, err);
+      const cachedValue =
+        err instanceof SyntaxError
+          ? await this.redis.get(key).catch(() => null)
+          : null;
+
+      console.error(`[VenueCache.get] Failed to retrieve key "${key}":`, err, {
+        cachedValueType: cachedValue === null ? "null" : typeof cachedValue,
+        cachedValuePreview:
+          cachedValue === null ? null : this.getValuePreview(cachedValue),
+      });
       return null;
     }
   }

--- a/web-service/src/lib/services/venue-generation-service.ts
+++ b/web-service/src/lib/services/venue-generation-service.ts
@@ -210,7 +210,7 @@ export async function generateVenues(sessionId: string): Promise<readonly Venue[
       categories,
       maxPrice
     );
-    const safeCandidates = applySafetyFilter(candidates);
+    const safeCandidates = applySafetyFilter(candidates, categories);
     const poolId = await createCandidatePool(sessionId, "initial_generation");
 
     await insertCandidatePoolItems(

--- a/web-service/src/lib/services/venue-generation-service.ts
+++ b/web-service/src/lib/services/venue-generation-service.ts
@@ -88,6 +88,7 @@ type InsertVenueRow = {
   readonly lng: number;
   readonly price_level: number;
   readonly rating: number;
+  readonly photo_urls: readonly string[];
   readonly photo_url: string | null;
   readonly tags: readonly string[];
   readonly round: number;
@@ -122,6 +123,7 @@ type InsertCandidatePoolItemRow = {
   readonly lng: number;
   readonly price_level: number;
   readonly rating: number;
+  readonly photo_urls: readonly string[];
   readonly photo_url: string | null;
   readonly raw_types: readonly string[];
   readonly raw_tags: readonly string[];
@@ -222,6 +224,7 @@ export async function generateVenues(sessionId: string): Promise<readonly Venue[
         lng: candidate.location.lng,
         price_level: candidate.priceLevel === 0 ? 1 : candidate.priceLevel,
         rating: candidate.rating,
+        photo_urls: candidate.photoUrls,
         photo_url: buildGooglePlacePhotoUrl(candidate.photoReference),
         raw_types: candidate.types,
         raw_tags: [],
@@ -254,6 +257,7 @@ export async function generateVenues(sessionId: string): Promise<readonly Venue[
           lng: venue.location.lng,
           price_level: venue.priceLevel === 0 ? 1 : venue.priceLevel,
           rating: venue.rating,
+          photo_urls: venue.photoUrls,
           photo_url: buildGooglePlacePhotoUrl(venue.photoReference),
           tags: venue.tags,
           round,

--- a/web-service/src/lib/services/venue-retry-service.ts
+++ b/web-service/src/lib/services/venue-retry-service.ts
@@ -74,6 +74,7 @@ type InsertVenueRow = {
   readonly lng: number;
   readonly price_level: number;
   readonly rating: number;
+  readonly photo_urls: readonly string[];
   readonly photo_url: string | null;
   readonly tags: readonly string[];
   readonly round: number;
@@ -89,6 +90,7 @@ type InsertVenueRow = {
 
 type RetryVenueCandidate = PlaceCandidate &
   Partial<CuratedVenueCandidate> & {
+    readonly photoUrls: readonly string[];
     readonly photoUrl: string | null;
   };
 
@@ -283,11 +285,19 @@ async function buildSurfacedVenueRows(
       midpoint,
     );
     const roundPicks = curated.slice(0, 4);
-    const photoUrlsByPlaceId = new Map(
-      remaining.map((candidate) => [candidate.placeId, candidate.photoUrl]),
+    const venuePhotosByPlaceId = new Map(
+      remaining.map((candidate) => [
+        candidate.placeId,
+        {
+          primary: candidate.photoUrl,
+          all: candidate.photoUrls,
+        },
+      ]),
     );
 
     roundPicks.forEach((venue, index) => {
+      const venuePhotos = venuePhotosByPlaceId.get(venue.placeId);
+
       selectedRows.push({
         session_id: sessionId,
         place_id: venue.placeId,
@@ -298,7 +308,8 @@ async function buildSurfacedVenueRows(
         lng: venue.location.lng,
         price_level: venue.priceLevel === 0 ? 1 : venue.priceLevel,
         rating: venue.rating,
-        photo_url: photoUrlsByPlaceId.get(venue.placeId) ?? null,
+        photo_urls: venuePhotos?.all ?? [],
+        photo_url: venuePhotos?.primary ?? null,
         tags: venue.tags,
         round,
         position: index + 1,
@@ -335,7 +346,9 @@ function toPlaceCandidate(
     priceLevel: candidate.priceLevel,
     rating: candidate.rating,
     reviewCount: 250,
+    photoReferences: [],
     photoReference: null,
+    photoUrls: candidate.photoUrls,
     photoUrl: candidate.photoUrl,
     category: candidate.category,
     tags: candidate.rawTags,

--- a/web-service/src/lib/types/__tests__/candidate-pool.test.ts
+++ b/web-service/src/lib/types/__tests__/candidate-pool.test.ts
@@ -39,7 +39,11 @@ describe("candidate pool type mappers", () => {
       lng: -97.74,
       price_level: 2,
       rating: 4.6,
-      photo_url: null,
+      photo_url: "https://example.com/photo-1.jpg",
+      photo_urls: [
+        "https://example.com/photo-1.jpg",
+        "https://example.com/photo-2.jpg",
+      ],
       raw_types: ["restaurant", "cafe"],
       raw_tags: ["cozy"],
       source_rank: 3,
@@ -52,10 +56,41 @@ describe("candidate pool type mappers", () => {
     expect(item.poolId).toBe("pool-1");
     expect(item.placeId).toBe("place-1");
     expect(item.category).toBe("RESTAURANT");
+    expect(item.photoUrl).toBe("https://example.com/photo-1.jpg");
+    expect(item.photoUrls).toEqual([
+      "https://example.com/photo-1.jpg",
+      "https://example.com/photo-2.jpg",
+    ]);
     expect(item.rawTypes).toEqual(["restaurant", "cafe"]);
     expect(item.rawTags).toEqual(["cozy"]);
     expect(item.sourceRank).toBe(3);
     expect(item.createdAt.toISOString()).toBe("2026-04-02T10:05:00.000Z");
+  });
+
+  it("falls back to the primary photo when a legacy row has no photo collection", () => {
+    const row: SessionCandidatePoolItemRow = {
+      id: "item-2",
+      pool_id: "pool-1",
+      place_id: "place-2",
+      name: "Night Owl",
+      category: "BAR",
+      address: "2 Main St",
+      lat: 30.27,
+      lng: -97.75,
+      price_level: 3,
+      rating: 4.4,
+      photo_url: "https://example.com/legacy-photo.jpg",
+      photo_urls: null,
+      raw_types: ["bar"],
+      raw_tags: ["cocktails"],
+      source_rank: 1,
+      created_at: "2026-04-02T10:07:00Z",
+    };
+
+    const item = toSessionCandidatePoolItem(row);
+
+    expect(item.photoUrl).toBe("https://example.com/legacy-photo.jpg");
+    expect(item.photoUrls).toEqual(["https://example.com/legacy-photo.jpg"]);
   });
 
   it("maps a generation batch row to the app-level shape", () => {

--- a/web-service/src/lib/types/__tests__/candidate-pool.test.ts
+++ b/web-service/src/lib/types/__tests__/candidate-pool.test.ts
@@ -93,6 +93,41 @@ describe("candidate pool type mappers", () => {
     expect(item.photoUrls).toEqual(["https://example.com/legacy-photo.jpg"]);
   });
 
+  it("normalizes persisted absolute proxy photo urls back to relative paths", () => {
+    const row: SessionCandidatePoolItemRow = {
+      id: "item-3",
+      pool_id: "pool-1",
+      place_id: "place-3",
+      name: "Skate Night",
+      category: "ACTIVITY",
+      address: "3 Main St",
+      lat: 30.28,
+      lng: -97.76,
+      price_level: 2,
+      rating: 4.5,
+      photo_url:
+        "https://dateflow.test/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-a&maxHeightPx=1200",
+      photo_urls: [
+        "https://dateflow.test/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-a&maxHeightPx=1200",
+        "https://dateflow.test/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-b&maxHeightPx=1200",
+      ],
+      raw_types: ["roller_skating_rink"],
+      raw_tags: ["playful"],
+      source_rank: 2,
+      created_at: "2026-04-02T10:09:00Z",
+    };
+
+    const item = toSessionCandidatePoolItem(row);
+
+    expect(item.photoUrl).toBe(
+      "/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-a&maxHeightPx=1200",
+    );
+    expect(item.photoUrls).toEqual([
+      "/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-a&maxHeightPx=1200",
+      "/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-b&maxHeightPx=1200",
+    ]);
+  });
+
   it("maps a generation batch row to the app-level shape", () => {
     const row: GenerationBatchRow = {
       id: "batch-1",

--- a/web-service/src/lib/types/__tests__/match-result.test.ts
+++ b/web-service/src/lib/types/__tests__/match-result.test.ts
@@ -16,6 +16,10 @@ describe("match result type mappers", () => {
       price_level: 2,
       rating: 4.6,
       photo_url: "https://example.com/photo.jpg",
+      photo_urls: [
+        "https://example.com/photo.jpg",
+        "https://example.com/photo-2.jpg",
+      ],
       tags: ["cozy", "patio"],
       round: 3,
       position: 4,
@@ -34,6 +38,10 @@ describe("match result type mappers", () => {
     expect(result.venue.placeId).toBe("place-12");
     expect(result.venue.name).toBe("Cafe Blue");
     expect(result.venue.photoUrl).toBe("https://example.com/photo.jpg");
+    expect(result.venue.photoUrls).toEqual([
+      "https://example.com/photo.jpg",
+      "https://example.com/photo-2.jpg",
+    ]);
     expect(result.venue.tags).toEqual(["cozy", "patio"]);
   });
 });

--- a/web-service/src/lib/types/__tests__/match-result.test.ts
+++ b/web-service/src/lib/types/__tests__/match-result.test.ts
@@ -44,4 +44,44 @@ describe("match result type mappers", () => {
     ]);
     expect(result.venue.tags).toEqual(["cozy", "patio"]);
   });
+
+  it("normalizes persisted absolute proxy photo urls back to relative paths", () => {
+    const row: MatchResultRow = {
+      session_id: "session-2",
+      matched_at: "2026-04-02T19:30:00Z",
+      id: "venue-22",
+      place_id: "place-22",
+      name: "Branch Brook",
+      category: "ACTIVITY",
+      address: "22 Main St",
+      lat: 40.75,
+      lng: -74.18,
+      price_level: 2,
+      rating: 4.7,
+      photo_url:
+        "https://dateflow.test/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-a&maxHeightPx=1200",
+      photo_urls: [
+        "https://dateflow.test/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-a&maxHeightPx=1200",
+        "https://dateflow.test/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-b&maxHeightPx=1200",
+      ],
+      tags: ["playful"],
+      round: 1,
+      position: 1,
+      score_category_overlap: 0.9,
+      score_distance_to_midpoint: 0.8,
+      score_first_date_suitability: 0.9,
+      score_quality_signal: 0.85,
+      score_time_of_day_fit: 0.7,
+    };
+
+    const result = toMatchResult(row);
+
+    expect(result.venue.photoUrl).toBe(
+      "/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-a&maxHeightPx=1200",
+    );
+    expect(result.venue.photoUrls).toEqual([
+      "/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-a&maxHeightPx=1200",
+      "/api/places/photos?name=places%2Fabc%2Fphotos%2Fref-b&maxHeightPx=1200",
+    ]);
+  });
 });

--- a/web-service/src/lib/types/__tests__/session.test.ts
+++ b/web-service/src/lib/types/__tests__/session.test.ts
@@ -7,6 +7,7 @@ describe("toSession", () => {
     id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     status: "pending_b",
     creator_display_name: "Alex",
+    invitee_display_name: null,
     created_at: "2026-03-27T12:00:00Z",
     expires_at: "2026-03-29T12:00:00Z",
     matched_venue_id: null,
@@ -19,6 +20,7 @@ describe("toSession", () => {
     expect(session.id).toBe(baseRow.id);
     expect(session.status).toBe(baseRow.status);
     expect(session.creatorDisplayName).toBe(baseRow.creator_display_name);
+    expect(session.inviteeDisplayName).toBeNull();
     expect(session.matchedVenueId).toBe(baseRow.matched_venue_id);
   });
 
@@ -47,5 +49,14 @@ describe("toSession", () => {
 
     expect(session.matchedVenueId).toBe("venue-abc-123");
     expect(session.matchedAt?.toISOString()).toBe("2026-03-28T13:00:00.000Z");
+  });
+
+  it("passes through a non-null invitee display name", () => {
+    const session = toSession({
+      ...baseRow,
+      invitee_display_name: "Jordan",
+    });
+
+    expect(session.inviteeDisplayName).toBe("Jordan");
   });
 });

--- a/web-service/src/lib/types/candidate-pool.ts
+++ b/web-service/src/lib/types/candidate-pool.ts
@@ -1,4 +1,5 @@
 import type { Category } from "./preference";
+import { normalizeProxiedPhotoUrl } from "../places-photo-url";
 
 export type CandidatePoolSource = "initial_generation" | "full_regeneration";
 export type GenerationStrategy =
@@ -76,24 +77,6 @@ export type GenerationBatchRow = {
   readonly created_at: string;
 };
 
-function normalizePhotoUrl(photoUrl: string): string {
-  if (photoUrl.startsWith("/")) {
-    return photoUrl;
-  }
-
-  try {
-    const parsed = new URL(photoUrl);
-
-    if (parsed.pathname === "/api/places/photos") {
-      return `${parsed.pathname}${parsed.search}`;
-    }
-  } catch {
-    return photoUrl;
-  }
-
-  return photoUrl;
-}
-
 export function toSessionCandidatePool(
   row: SessionCandidatePoolRow,
 ): SessionCandidatePool {
@@ -109,10 +92,10 @@ function resolvePhotoUrls(
   row: Pick<SessionCandidatePoolItemRow, "photo_url" | "photo_urls">,
 ): readonly string[] {
   if (Array.isArray(row.photo_urls) && row.photo_urls.length > 0) {
-    return row.photo_urls.map(normalizePhotoUrl);
+    return row.photo_urls.map(normalizeProxiedPhotoUrl);
   }
 
-  return row.photo_url ? [normalizePhotoUrl(row.photo_url)] : [];
+  return row.photo_url ? [normalizeProxiedPhotoUrl(row.photo_url)] : [];
 }
 
 export function toSessionCandidatePoolItem(

--- a/web-service/src/lib/types/candidate-pool.ts
+++ b/web-service/src/lib/types/candidate-pool.ts
@@ -24,6 +24,7 @@ export type SessionCandidatePoolItem = {
   readonly lng: number;
   readonly priceLevel: number;
   readonly rating: number;
+  readonly photoUrls: readonly string[];
   readonly photoUrl: string | null;
   readonly rawTypes: readonly string[];
   readonly rawTags: readonly string[];
@@ -58,6 +59,7 @@ export type SessionCandidatePoolItemRow = {
   readonly lng: number;
   readonly price_level: number;
   readonly rating: number;
+  readonly photo_urls?: string[] | null;
   readonly photo_url: string | null;
   readonly raw_types: string[];
   readonly raw_tags: string[];
@@ -85,9 +87,21 @@ export function toSessionCandidatePool(
   };
 }
 
+function resolvePhotoUrls(
+  row: Pick<SessionCandidatePoolItemRow, "photo_url" | "photo_urls">,
+): readonly string[] {
+  if (Array.isArray(row.photo_urls) && row.photo_urls.length > 0) {
+    return row.photo_urls;
+  }
+
+  return row.photo_url ? [row.photo_url] : [];
+}
+
 export function toSessionCandidatePoolItem(
   row: SessionCandidatePoolItemRow,
 ): SessionCandidatePoolItem {
+  const photoUrls = resolvePhotoUrls(row);
+
   return {
     id: row.id,
     poolId: row.pool_id,
@@ -99,7 +113,8 @@ export function toSessionCandidatePoolItem(
     lng: row.lng,
     priceLevel: row.price_level,
     rating: row.rating,
-    photoUrl: row.photo_url,
+    photoUrls,
+    photoUrl: photoUrls[0] ?? null,
     rawTypes: row.raw_types,
     rawTags: row.raw_tags,
     sourceRank: row.source_rank,

--- a/web-service/src/lib/types/candidate-pool.ts
+++ b/web-service/src/lib/types/candidate-pool.ts
@@ -76,6 +76,24 @@ export type GenerationBatchRow = {
   readonly created_at: string;
 };
 
+function normalizePhotoUrl(photoUrl: string): string {
+  if (photoUrl.startsWith("/")) {
+    return photoUrl;
+  }
+
+  try {
+    const parsed = new URL(photoUrl);
+
+    if (parsed.pathname === "/api/places/photos") {
+      return `${parsed.pathname}${parsed.search}`;
+    }
+  } catch {
+    return photoUrl;
+  }
+
+  return photoUrl;
+}
+
 export function toSessionCandidatePool(
   row: SessionCandidatePoolRow,
 ): SessionCandidatePool {
@@ -91,10 +109,10 @@ function resolvePhotoUrls(
   row: Pick<SessionCandidatePoolItemRow, "photo_url" | "photo_urls">,
 ): readonly string[] {
   if (Array.isArray(row.photo_urls) && row.photo_urls.length > 0) {
-    return row.photo_urls;
+    return row.photo_urls.map(normalizePhotoUrl);
   }
 
-  return row.photo_url ? [row.photo_url] : [];
+  return row.photo_url ? [normalizePhotoUrl(row.photo_url)] : [];
 }
 
 export function toSessionCandidatePoolItem(

--- a/web-service/src/lib/types/session.ts
+++ b/web-service/src/lib/types/session.ts
@@ -29,6 +29,7 @@ export type Session = {
   readonly id: string;
   readonly status: SessionStatus;
   readonly creatorDisplayName: string;
+  readonly inviteeDisplayName: string | null;
   readonly createdAt: Date;
   readonly expiresAt: Date;
   readonly matchedVenueId: string | null;
@@ -60,6 +61,7 @@ export type SessionRow = {
   readonly id: string;
   readonly status: SessionStatus;
   readonly creator_display_name: string;
+  readonly invitee_display_name: string | null;
   readonly created_at: string;
   readonly expires_at: string;
   readonly matched_venue_id: string | null;
@@ -77,6 +79,7 @@ export function toSession(row: SessionRow): Session {
     id: row.id,
     status: row.status,
     creatorDisplayName: row.creator_display_name,
+    inviteeDisplayName: row.invitee_display_name,
     createdAt: new Date(row.created_at),
     expiresAt: new Date(row.expires_at),
     matchedVenueId: row.matched_venue_id,

--- a/web-service/src/lib/types/venue.ts
+++ b/web-service/src/lib/types/venue.ts
@@ -1,4 +1,5 @@
 import type { Category, Location } from "./preference";
+import { normalizeProxiedPhotoUrl } from "../places-photo-url";
 
 /**
  * The five independent scoring dimensions that measure how well a venue
@@ -124,30 +125,12 @@ export type VenueRow = {
   readonly score_time_of_day_fit: number;
 };
 
-function normalizePhotoUrl(photoUrl: string): string {
-  if (photoUrl.startsWith("/")) {
-    return photoUrl;
-  }
-
-  try {
-    const parsed = new URL(photoUrl);
-
-    if (parsed.pathname === "/api/places/photos") {
-      return `${parsed.pathname}${parsed.search}`;
-    }
-  } catch {
-    return photoUrl;
-  }
-
-  return photoUrl;
-}
-
 function resolvePhotoUrls(row: Pick<VenueRow, "photo_url" | "photo_urls">): readonly string[] {
   if (Array.isArray(row.photo_urls) && row.photo_urls.length > 0) {
-    return row.photo_urls.map(normalizePhotoUrl);
+    return row.photo_urls.map(normalizeProxiedPhotoUrl);
   }
 
-  return row.photo_url ? [normalizePhotoUrl(row.photo_url)] : [];
+  return row.photo_url ? [normalizeProxiedPhotoUrl(row.photo_url)] : [];
 }
 
 /**

--- a/web-service/src/lib/types/venue.ts
+++ b/web-service/src/lib/types/venue.ts
@@ -124,12 +124,30 @@ export type VenueRow = {
   readonly score_time_of_day_fit: number;
 };
 
-function resolvePhotoUrls(row: Pick<VenueRow, "photo_url" | "photo_urls">): readonly string[] {
-  if (Array.isArray(row.photo_urls) && row.photo_urls.length > 0) {
-    return row.photo_urls;
+function normalizePhotoUrl(photoUrl: string): string {
+  if (photoUrl.startsWith("/")) {
+    return photoUrl;
   }
 
-  return row.photo_url ? [row.photo_url] : [];
+  try {
+    const parsed = new URL(photoUrl);
+
+    if (parsed.pathname === "/api/places/photos") {
+      return `${parsed.pathname}${parsed.search}`;
+    }
+  } catch {
+    return photoUrl;
+  }
+
+  return photoUrl;
+}
+
+function resolvePhotoUrls(row: Pick<VenueRow, "photo_url" | "photo_urls">): readonly string[] {
+  if (Array.isArray(row.photo_urls) && row.photo_urls.length > 0) {
+    return row.photo_urls.map(normalizePhotoUrl);
+  }
+
+  return row.photo_url ? [normalizePhotoUrl(row.photo_url)] : [];
 }
 
 /**

--- a/web-service/src/lib/types/venue.ts
+++ b/web-service/src/lib/types/venue.ts
@@ -64,8 +64,10 @@ export function computeVenueComposite(
  * **position:** 1-4 within the round (the venue's rank in that round).
  * **tags:** AI-generated labels ("cozy", "live music", "romantic", etc.) that
  *   explain why this venue was chosen. Shown in the UI to build trust in the curation.
- * **photoUrl:** Direct URL to a venue photo, or null if not available.
- *   Always a static URL (proxied server-side) — never leaks Google Places API key.
+ * **photoUrls:** Ordered photo collection for the venue. The first item is the
+ *   primary photo used by older single-image surfaces.
+ * **photoUrl:** Backward-compatible primary photo, or null if not available.
+ *   Always a static URL (proxied server-side), never leaks Google Places API key.
  * **category:** The primary category (RESTAURANT, BAR, ACTIVITY, EVENT).
  *   Normalized from Google Places types.
  * **rating, priceLevel:** From Google Places. Rating is 0–5 (decimal).
@@ -82,6 +84,7 @@ export type Venue = {
   readonly lng: number;
   readonly priceLevel: number;
   readonly rating: number;
+  readonly photoUrls: readonly string[];
   readonly photoUrl: string | null;
   readonly tags: readonly string[];
   readonly round: number;
@@ -109,6 +112,7 @@ export type VenueRow = {
   readonly lng: number;
   readonly price_level: number;
   readonly rating: number;
+  readonly photo_urls?: string[] | null;
   readonly photo_url: string | null;
   readonly tags: string[];
   readonly round: number;
@@ -120,11 +124,21 @@ export type VenueRow = {
   readonly score_time_of_day_fit: number;
 };
 
+function resolvePhotoUrls(row: Pick<VenueRow, "photo_url" | "photo_urls">): readonly string[] {
+  if (Array.isArray(row.photo_urls) && row.photo_urls.length > 0) {
+    return row.photo_urls;
+  }
+
+  return row.photo_url ? [row.photo_url] : [];
+}
+
 /**
  * Converts a raw Supabase row into an app-level Venue.
  * Groups the five score columns into a single VenueScore object.
  */
 export function toVenue(row: VenueRow): Venue {
+  const photoUrls = resolvePhotoUrls(row);
+
   return {
     id: row.id,
     sessionId: row.session_id,
@@ -136,7 +150,8 @@ export function toVenue(row: VenueRow): Venue {
     lng: row.lng,
     priceLevel: row.price_level,
     rating: row.rating,
-    photoUrl: row.photo_url,
+    photoUrls,
+    photoUrl: photoUrls[0] ?? null,
     tags: row.tags,
     round: row.round,
     position: row.position,
@@ -165,9 +180,9 @@ export function toVenue(row: VenueRow): Venue {
  * A venue candidate returned by Google Places Nearby Search API.
  * These are raw results before any custom scoring or filtering.
  *
- * **photoReference:** A string reference that can be resolved to a URL server-side.
- *   We never pass Google API keys to the client, so we fetch photos on the server
- *   and serve them back — this is just the key to look it up later.
+ * **photoReferences:** Ordered Google photo references for this place.
+ * **photoReference:** Backward-compatible primary reference.
+ * **photoUrls:** Ordered proxied photo URLs derived from the references.
  *
  * **types:** Google Places types (e.g., "restaurant", "bar", "tourist_attraction").
  *   The VenueGenerationService normalizes these to our Category enum.
@@ -181,7 +196,9 @@ export type PlaceCandidate = {
   readonly priceLevel: number;
   readonly rating: number;
   readonly reviewCount: number;
+  readonly photoReferences: readonly string[];
   readonly photoReference: string | null;
+  readonly photoUrls: readonly string[];
 };
 
 /**

--- a/web-service/supabase/migrations/009_add_photo_urls_to_venues_and_candidate_pools.sql
+++ b/web-service/supabase/migrations/009_add_photo_urls_to_venues_and_candidate_pools.sql
@@ -1,0 +1,19 @@
+alter table public.venues
+add column if not exists photo_urls text[] not null default '{}';
+
+update public.venues
+set photo_urls = case
+  when photo_url is null then '{}'
+  else array[photo_url]
+end
+where coalesce(array_length(photo_urls, 1), 0) = 0;
+
+alter table public.session_candidate_pool_items
+add column if not exists photo_urls text[] not null default '{}';
+
+update public.session_candidate_pool_items
+set photo_urls = case
+  when photo_url is null then '{}'
+  else array[photo_url]
+end
+where coalesce(array_length(photo_urls, 1), 0) = 0;

--- a/web-service/supabase/migrations/010_add_invitee_display_name_to_sessions.sql
+++ b/web-service/supabase/migrations/010_add_invitee_display_name_to_sessions.sql
@@ -1,0 +1,2 @@
+alter table public.sessions
+add column if not exists invitee_display_name text;


### PR DESCRIPTION
## Summary
- add multi-photo support to venue and candidate-pool domain models while keeping `photoUrl` as the primary compatibility field
- persist ordered `photo_urls` through generation, retry, demo, and add the Supabase migration to backfill existing rows
- update swipe and result surfaces to use compact galleries and expand result metadata to publish the full image set

## Test plan
- [x] bun run test -- 'src/lib/types/__tests__/candidate-pool.test.ts' 'src/lib/types/__tests__/match-result.test.ts' 'src/lib/services/__tests__/places-api-client.test.ts' 'src/lib/services/__tests__/venue-generation-service.test.ts' 'src/lib/services/__tests__/venue-retry-runtime.test.ts' 'src/app/plan/[id]/swipe/__tests__/swipe-deck-card.test.ts' 'src/app/plan/[id]/results/__tests__/result-screen.test.tsx' 'src/app/plan/[id]/results/__tests__/page.test.tsx'
- [x] bun run lint
- [x] bun run build