### PR TITLE
Add DS-06 accounts and history flows

### DIFF
--- a/web-service/.gitignore
+++ b/web-service/.gitignore
@@ -29,6 +29,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+.mcp.json
 
 # env files
 .env*

--- a/web-service/.mcp.json
+++ b/web-service/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=jelskqtmqodqlfsytdzr"
+    }
+  }
+}

--- a/web-service/.mcp.json
+++ b/web-service/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "supabase": {
-      "type": "http",
-      "url": "https://mcp.supabase.com/mcp?project_ref=jelskqtmqodqlfsytdzr"
-    }
-  }
-}

--- a/web-service/src/app/__tests__/globals-motion.test.ts
+++ b/web-service/src/app/__tests__/globals-motion.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("globals.css motion system", () => {
+  const css = readFileSync(
+    resolve(process.cwd(), "src/app/globals.css"),
+    "utf8",
+  );
+
+  it("includes auth sheet and save prompt keyframes", () => {
+    expect(css).toContain("@keyframes authSheetEnter");
+    expect(css).toContain("@keyframes savePromptReveal");
+  });
+
+  it("includes a reduced-motion fallback block", () => {
+    expect(css).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(css).toContain("animation-duration: 1ms");
+  });
+});

--- a/web-service/src/app/api/auth/login/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/login/__tests__/route.test.ts
@@ -128,4 +128,18 @@ describe("POST /api/auth/login", () => {
     });
     expect(mockLogin).not.toHaveBeenCalled();
   });
+
+  it("returns 400 when provider redirectTo is not a same-origin /history URL", async () => {
+    const response = await POST(
+      makeRequest({
+        provider: "google",
+        redirectTo: "https://evil.example/steal",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("redirectTo must be a same-origin /history URL");
+    expect(mockBeginGoogleOAuth).not.toHaveBeenCalled();
+  });
 });

--- a/web-service/src/app/api/auth/login/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/login/__tests__/route.test.ts
@@ -4,7 +4,7 @@ const mockLogin = vi.fn();
 const mockBeginGoogleOAuth = vi.fn();
 const mockBeginAppleOAuth = vi.fn();
 
-vi.mock("../../../../../../src/lib/services/account-service", () => ({
+vi.mock("../../../../../lib/services/account-service", () => ({
   login: (...args: unknown[]) => mockLogin(...args),
   beginGoogleOAuth: (...args: unknown[]) => mockBeginGoogleOAuth(...args),
   beginAppleOAuth: (...args: unknown[]) => mockBeginAppleOAuth(...args),

--- a/web-service/src/app/api/auth/login/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/login/__tests__/route.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockLogin = vi.fn();
 const mockBeginGoogleOAuth = vi.fn();
+const mockBeginAppleOAuth = vi.fn();
 
 vi.mock("../../../../../../src/lib/services/account-service", () => ({
   login: (...args: unknown[]) => mockLogin(...args),
   beginGoogleOAuth: (...args: unknown[]) => mockBeginGoogleOAuth(...args),
+  beginAppleOAuth: (...args: unknown[]) => mockBeginAppleOAuth(...args),
 }));
 
 import { POST } from "../route";
@@ -31,6 +33,9 @@ describe("POST /api/auth/login", () => {
     });
     mockBeginGoogleOAuth.mockResolvedValue(
       "https://supabase.test/auth/v1/authorize?provider=google",
+    );
+    mockBeginAppleOAuth.mockResolvedValue(
+      "https://supabase.test/auth/v1/authorize?provider=apple",
     );
   });
 
@@ -101,6 +106,25 @@ describe("POST /api/auth/login", () => {
     );
     expect(body).toEqual({
       url: "https://supabase.test/auth/v1/authorize?provider=google",
+    });
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it("returns a redirect url when provider apple is requested", async () => {
+    const response = await POST(
+      makeRequest({
+        provider: "apple",
+        redirectTo: "http://localhost:3000/history",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockBeginAppleOAuth).toHaveBeenCalledWith(
+      "http://localhost:3000/history",
+    );
+    expect(body).toEqual({
+      url: "https://supabase.test/auth/v1/authorize?provider=apple",
     });
     expect(mockLogin).not.toHaveBeenCalled();
   });

--- a/web-service/src/app/api/auth/login/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/login/__tests__/route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLogin = vi.fn();
+const mockBeginGoogleOAuth = vi.fn();
+
+vi.mock("../../../../../../src/lib/services/account-service", () => ({
+  login: (...args: unknown[]) => mockLogin(...args),
+  beginGoogleOAuth: (...args: unknown[]) => mockBeginGoogleOAuth(...args),
+}));
+
+import { POST } from "../route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogin.mockResolvedValue({
+      token: "token-456",
+      account: {
+        id: "account-1",
+        email: "alex@example.com",
+        createdAt: new Date("2026-04-13T20:00:00Z"),
+      },
+    });
+    mockBeginGoogleOAuth.mockResolvedValue(
+      "https://supabase.test/auth/v1/authorize?provider=google",
+    );
+  });
+
+  it("returns 200 with the account and token", async () => {
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+        password: "supersecret",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockLogin).toHaveBeenCalledWith(
+      "alex@example.com",
+      "supersecret",
+    );
+    expect(body).toEqual({
+      account: {
+        id: "account-1",
+        email: "alex@example.com",
+        createdAt: "2026-04-13T20:00:00.000Z",
+      },
+      token: "token-456",
+    });
+  });
+
+  it("returns 400 when password is missing", async () => {
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("password is required and must be a string");
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when credentials are invalid", async () => {
+    mockLogin.mockRejectedValue(new Error("Invalid credentials"));
+
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+        password: "wrongpass",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Invalid credentials");
+  });
+
+  it("returns a redirect url when provider google is requested", async () => {
+    const response = await POST(
+      makeRequest({
+        provider: "google",
+        redirectTo: "http://localhost:3000/history",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockBeginGoogleOAuth).toHaveBeenCalledWith(
+      "http://localhost:3000/history",
+    );
+    expect(body).toEqual({
+      url: "https://supabase.test/auth/v1/authorize?provider=google",
+    });
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+});

--- a/web-service/src/app/api/auth/login/route.ts
+++ b/web-service/src/app/api/auth/login/route.ts
@@ -3,7 +3,7 @@ import {
   beginAppleOAuth,
   beginGoogleOAuth,
   login,
-} from "../../../../../src/lib/services/account-service";
+} from "../../../../lib/services/account-service";
 
 type LoginBody = {
   email?: unknown;

--- a/web-service/src/app/api/auth/login/route.ts
+++ b/web-service/src/app/api/auth/login/route.ts
@@ -13,6 +13,7 @@ type LoginBody = {
 };
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const HISTORY_PATH = "/history";
 
 function validate(body: LoginBody): { email: string; password: string } {
   if (typeof body.email !== "string" || !EMAIL_PATTERN.test(body.email)) {
@@ -27,6 +28,22 @@ function validate(body: LoginBody): { email: string; password: string } {
     email: body.email,
     password: body.password,
   };
+}
+
+function sanitizeRedirectTo(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const appOrigin = new URL(appUrl).origin;
+  const redirectUrl = new URL(value, appOrigin);
+
+  if (redirectUrl.origin !== appOrigin || redirectUrl.pathname !== HISTORY_PATH) {
+    throw new Error("redirectTo must be a same-origin /history URL");
+  }
+
+  return redirectUrl.toString();
 }
 
 export async function POST(request: Request) {
@@ -52,16 +69,12 @@ export async function POST(request: Request) {
     const typedBody = body as LoginBody;
 
     if (typedBody.provider === "google") {
-      const url = await beginGoogleOAuth(
-        typeof typedBody.redirectTo === "string" ? typedBody.redirectTo : undefined,
-      );
+      const url = await beginGoogleOAuth(sanitizeRedirectTo(typedBody.redirectTo));
       return NextResponse.json({ url });
     }
 
     if (typedBody.provider === "apple") {
-      const url = await beginAppleOAuth(
-        typeof typedBody.redirectTo === "string" ? typedBody.redirectTo : undefined,
-      );
+      const url = await beginAppleOAuth(sanitizeRedirectTo(typedBody.redirectTo));
       return NextResponse.json({ url });
     }
 
@@ -81,7 +94,8 @@ export async function POST(request: Request) {
 
     if (
       message === "email must be a valid email address" ||
-      message === "password is required and must be a string"
+      message === "password is required and must be a string" ||
+      message === "redirectTo must be a same-origin /history URL"
     ) {
       return NextResponse.json({ error: message }, { status: 400 });
     }

--- a/web-service/src/app/api/auth/login/route.ts
+++ b/web-service/src/app/api/auth/login/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import {
+  beginGoogleOAuth,
+  login,
+} from "../../../../../src/lib/services/account-service";
+
+type LoginBody = {
+  email?: unknown;
+  password?: unknown;
+  provider?: unknown;
+  redirectTo?: unknown;
+};
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validate(body: LoginBody): { email: string; password: string } {
+  if (typeof body.email !== "string" || !EMAIL_PATTERN.test(body.email)) {
+    throw new Error("email must be a valid email address");
+  }
+
+  if (typeof body.password !== "string") {
+    throw new Error("password is required and must be a string");
+  }
+
+  return {
+    email: body.email,
+    password: body.password,
+  };
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must be valid JSON" },
+      { status: 400 },
+    );
+  }
+
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: "Request body must be a JSON object" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const typedBody = body as LoginBody;
+
+    if (typedBody.provider === "google") {
+      const url = await beginGoogleOAuth(
+        typeof typedBody.redirectTo === "string" ? typedBody.redirectTo : undefined,
+      );
+      return NextResponse.json({ url });
+    }
+
+    const { email, password } = validate(typedBody);
+    const result = await login(email, password);
+
+    return NextResponse.json({
+      account: {
+        id: result.account.id,
+        email: result.account.email,
+        createdAt: result.account.createdAt.toISOString(),
+      },
+      token: result.token,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+
+    if (
+      message === "email must be a valid email address" ||
+      message === "password is required and must be a string"
+    ) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    if (message === "Invalid credentials") {
+      return NextResponse.json({ error: message }, { status: 401 });
+    }
+
+    console.error("[POST /api/auth/login] Failed:", err);
+    return NextResponse.json(
+      { error: "Something went wrong. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/web-service/src/app/api/auth/login/route.ts
+++ b/web-service/src/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import {
+  beginAppleOAuth,
   beginGoogleOAuth,
   login,
 } from "../../../../../src/lib/services/account-service";
@@ -52,6 +53,13 @@ export async function POST(request: Request) {
 
     if (typedBody.provider === "google") {
       const url = await beginGoogleOAuth(
+        typeof typedBody.redirectTo === "string" ? typedBody.redirectTo : undefined,
+      );
+      return NextResponse.json({ url });
+    }
+
+    if (typedBody.provider === "apple") {
+      const url = await beginAppleOAuth(
         typeof typedBody.redirectTo === "string" ? typedBody.redirectTo : undefined,
       );
       return NextResponse.json({ url });

--- a/web-service/src/app/api/auth/me/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/me/__tests__/route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetAccountByAccessToken = vi.fn();
 
-vi.mock("../../../../../../src/lib/services/account-service", () => ({
+vi.mock("../../../../../lib/services/account-service", () => ({
   getAccountByAccessToken: (...args: unknown[]) =>
     mockGetAccountByAccessToken(...args),
 }));

--- a/web-service/src/app/api/auth/me/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/me/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetAccountByAccessToken = vi.fn();
+
+vi.mock("../../../../../../src/lib/services/account-service", () => ({
+  getAccountByAccessToken: (...args: unknown[]) =>
+    mockGetAccountByAccessToken(...args),
+}));
+
+import { GET } from "../route";
+
+function makeRequest(token = "token-123"): Request {
+  return new Request("http://localhost:3000/api/auth/me", {
+    method: "GET",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+describe("GET /api/auth/me", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccountByAccessToken.mockResolvedValue({
+      id: "account-1",
+      email: "alex@example.com",
+      createdAt: new Date("2026-04-13T20:00:00Z"),
+    });
+  });
+
+  it("returns the authenticated account", async () => {
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetAccountByAccessToken).toHaveBeenCalledWith("token-123");
+    expect(body).toEqual({
+      account: {
+        id: "account-1",
+        email: "alex@example.com",
+        createdAt: "2026-04-13T20:00:00.000Z",
+      },
+    });
+  });
+
+  it("returns 401 when the authorization header is missing", async () => {
+    const response = await GET(makeRequest(""));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Authorization header is required");
+    expect(mockGetAccountByAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the token is invalid", async () => {
+    mockGetAccountByAccessToken.mockRejectedValue(new Error("Invalid token"));
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Invalid token");
+  });
+});

--- a/web-service/src/app/api/auth/me/route.ts
+++ b/web-service/src/app/api/auth/me/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getAccountByAccessToken } from "../../../../../src/lib/services/account-service";
+import { getAccountByAccessToken } from "../../../../lib/services/account-service";
 
 function getBearerToken(header: string | null): string {
   if (!header) {

--- a/web-service/src/app/api/auth/me/route.ts
+++ b/web-service/src/app/api/auth/me/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getAccountByAccessToken } from "../../../../../src/lib/services/account-service";
+
+function getBearerToken(header: string | null): string {
+  if (!header) {
+    throw new Error("Authorization header is required");
+  }
+
+  if (!header.startsWith("Bearer ")) {
+    throw new Error("Authorization header must use Bearer token");
+  }
+
+  return header.slice("Bearer ".length).trim();
+}
+
+export async function GET(request: Request) {
+  try {
+    const token = getBearerToken(request.headers.get("authorization"));
+    const account = await getAccountByAccessToken(token);
+
+    return NextResponse.json({ account });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+
+    if (
+      message === "Authorization header is required" ||
+      message === "Authorization header must use Bearer token" ||
+      message === "Invalid token"
+    ) {
+      return NextResponse.json({ error: message }, { status: 401 });
+    }
+
+    console.error("[GET /api/auth/me] Failed:", err);
+    return NextResponse.json(
+      { error: "Something went wrong. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/web-service/src/app/api/auth/register/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/register/__tests__/route.test.ts
@@ -102,6 +102,23 @@ describe("POST /api/auth/register", () => {
     expect(body.error).toBe("Email already registered");
   });
 
+  it("returns 400 when email confirmation is required before sign-in", async () => {
+    mockRegister.mockRejectedValue(
+      new Error("Check your email to confirm your account"),
+    );
+
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+        password: "supersecret",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Check your email to confirm your account");
+  });
+
   it("links a finished anonymous session when linkSessionId and linkRole are provided", async () => {
     const response = await POST(
       makeRequest({

--- a/web-service/src/app/api/auth/register/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/register/__tests__/route.test.ts
@@ -137,6 +137,31 @@ describe("POST /api/auth/register", () => {
     );
   });
 
+  it("returns 201 with a warning when registration succeeds but session linking fails", async () => {
+    mockLinkSessionToAccount.mockRejectedValue(new Error("duplicate key"));
+
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+        password: "supersecret",
+        linkSessionId: "session-1",
+        linkRole: "b",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({
+      account: {
+        id: "account-1",
+        email: "alex@example.com",
+        createdAt: "2026-04-13T20:00:00.000Z",
+      },
+      token: "token-123",
+      warning: "Account created, but we could not link the provided session.",
+    });
+  });
+
   it("returns 400 when linkSessionId is present without linkRole", async () => {
     const response = await POST(
       makeRequest({

--- a/web-service/src/app/api/auth/register/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/register/__tests__/route.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRegister = vi.fn();
+const mockLinkSessionToAccount = vi.fn();
+
+vi.mock("../../../../../../src/lib/services/account-service", () => ({
+  register: (...args: unknown[]) => mockRegister(...args),
+}));
+
+vi.mock("../../../../../../src/lib/services/session-history-service", () => ({
+  linkSessionToAccount: (...args: unknown[]) => mockLinkSessionToAccount(...args),
+}));
+
+import { POST } from "../route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegister.mockResolvedValue({
+      token: "token-123",
+      account: {
+        id: "account-1",
+        email: "alex@example.com",
+        createdAt: new Date("2026-04-13T20:00:00Z"),
+      },
+    });
+    mockLinkSessionToAccount.mockResolvedValue(undefined);
+  });
+
+  it("returns 201 with the created account and token", async () => {
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+        password: "supersecret",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(mockRegister).toHaveBeenCalledWith(
+      "alex@example.com",
+      "supersecret",
+    );
+    expect(body).toEqual({
+      account: {
+        id: "account-1",
+        email: "alex@example.com",
+        createdAt: "2026-04-13T20:00:00.000Z",
+      },
+      token: "token-123",
+    });
+  });
+
+  it("returns 400 when email is invalid", async () => {
+    const response = await POST(
+      makeRequest({
+        email: "not-an-email",
+        password: "supersecret",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("email must be a valid email address");
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when password is too short", async () => {
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+        password: "short",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("password must be at least 8 characters");
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 for duplicate email", async () => {
+    mockRegister.mockRejectedValue(new Error("Email already registered"));
+
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+        password: "supersecret",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("Email already registered");
+  });
+
+  it("links a finished anonymous session when linkSessionId and linkRole are provided", async () => {
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+        password: "supersecret",
+        linkSessionId: "session-1",
+        linkRole: "b",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockLinkSessionToAccount).toHaveBeenCalledWith(
+      "session-1",
+      "account-1",
+      "b",
+    );
+  });
+
+  it("returns 400 when linkSessionId is present without linkRole", async () => {
+    const response = await POST(
+      makeRequest({
+        email: "alex@example.com",
+        password: "supersecret",
+        linkSessionId: "session-1",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe(
+      "linkRole is required when linkSessionId is provided",
+    );
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+});

--- a/web-service/src/app/api/auth/register/__tests__/route.test.ts
+++ b/web-service/src/app/api/auth/register/__tests__/route.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockRegister = vi.fn();
 const mockLinkSessionToAccount = vi.fn();
 
-vi.mock("../../../../../../src/lib/services/account-service", () => ({
+vi.mock("../../../../../lib/services/account-service", () => ({
   register: (...args: unknown[]) => mockRegister(...args),
 }));
 
-vi.mock("../../../../../../src/lib/services/session-history-service", () => ({
+vi.mock("../../../../../lib/services/session-history-service", () => ({
   linkSessionToAccount: (...args: unknown[]) => mockLinkSessionToAccount(...args),
 }));
 

--- a/web-service/src/app/api/auth/register/route.ts
+++ b/web-service/src/app/api/auth/register/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import { register } from "../../../../../src/lib/services/account-service";
+import { linkSessionToAccount } from "../../../../../src/lib/services/session-history-service";
+
+type RegisterBody = {
+  email?: unknown;
+  password?: unknown;
+  linkSessionId?: unknown;
+  linkRole?: unknown;
+};
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validate(body: RegisterBody): {
+  email: string;
+  password: string;
+  linkSessionId: string | null;
+  linkRole: "a" | "b" | null;
+} {
+  if (typeof body.email !== "string" || !EMAIL_PATTERN.test(body.email)) {
+    throw new Error("email must be a valid email address");
+  }
+
+  if (typeof body.password !== "string" || body.password.length < 8) {
+    throw new Error("password must be at least 8 characters");
+  }
+
+  if (
+    typeof body.linkSessionId === "string" &&
+    body.linkSessionId.length > 0 &&
+    body.linkRole !== "a" &&
+    body.linkRole !== "b"
+  ) {
+    throw new Error("linkRole is required when linkSessionId is provided");
+  }
+
+  return {
+    email: body.email,
+    password: body.password,
+    linkSessionId:
+      typeof body.linkSessionId === "string" && body.linkSessionId.length > 0
+        ? body.linkSessionId
+        : null,
+    linkRole: body.linkRole === "a" || body.linkRole === "b" ? body.linkRole : null,
+  };
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must be valid JSON" },
+      { status: 400 },
+    );
+  }
+
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: "Request body must be a JSON object" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const { email, password, linkSessionId, linkRole } = validate(
+      body as RegisterBody,
+    );
+    const result = await register(email, password);
+
+    if (linkSessionId && linkRole) {
+      await linkSessionToAccount(linkSessionId, result.account.id, linkRole);
+    }
+
+    return NextResponse.json(
+      {
+        account: {
+          id: result.account.id,
+          email: result.account.email,
+          createdAt: result.account.createdAt.toISOString(),
+        },
+        token: result.token,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+
+    if (
+      message === "email must be a valid email address" ||
+      message === "password must be at least 8 characters" ||
+      message === "linkRole is required when linkSessionId is provided"
+    ) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    if (message === "Email already registered") {
+      return NextResponse.json({ error: message }, { status: 409 });
+    }
+
+    console.error("[POST /api/auth/register] Failed:", err);
+    return NextResponse.json(
+      { error: "Something went wrong. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/web-service/src/app/api/auth/register/route.ts
+++ b/web-service/src/app/api/auth/register/route.ts
@@ -100,6 +100,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: message }, { status: 409 });
     }
 
+    if (message === "Check your email to confirm your account") {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
     console.error("[POST /api/auth/register] Failed:", err);
     return NextResponse.json(
       { error: "Something went wrong. Please try again." },

--- a/web-service/src/app/api/auth/register/route.ts
+++ b/web-service/src/app/api/auth/register/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { register } from "../../../../../src/lib/services/account-service";
-import { linkSessionToAccount } from "../../../../../src/lib/services/session-history-service";
+import { register } from "../../../../lib/services/account-service";
+import { linkSessionToAccount } from "../../../../lib/services/session-history-service";
 
 type RegisterBody = {
   email?: unknown;

--- a/web-service/src/app/api/auth/register/route.ts
+++ b/web-service/src/app/api/auth/register/route.ts
@@ -69,22 +69,34 @@ export async function POST(request: Request) {
       body as RegisterBody,
     );
     const result = await register(email, password);
+    const responseBody = {
+      account: {
+        id: result.account.id,
+        email: result.account.email,
+        createdAt: result.account.createdAt.toISOString(),
+      },
+      token: result.token,
+    };
 
     if (linkSessionId && linkRole) {
-      await linkSessionToAccount(linkSessionId, result.account.id, linkRole);
+      try {
+        await linkSessionToAccount(linkSessionId, result.account.id, linkRole);
+      } catch (linkErr) {
+        console.error(
+          "[POST /api/auth/register] Session link failed after successful registration:",
+          linkErr,
+        );
+        return NextResponse.json(
+          {
+            ...responseBody,
+            warning: "Account created, but we could not link the provided session.",
+          },
+          { status: 201 },
+        );
+      }
     }
 
-    return NextResponse.json(
-      {
-        account: {
-          id: result.account.id,
-          email: result.account.email,
-          createdAt: result.account.createdAt.toISOString(),
-        },
-        token: result.token,
-      },
-      { status: 201 },
-    );
+    return NextResponse.json(responseBody, { status: 201 });
   } catch (err) {
     const message = err instanceof Error ? err.message : "";
 

--- a/web-service/src/app/api/sessions/history/__tests__/route.test.ts
+++ b/web-service/src/app/api/sessions/history/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetUser = vi.fn();
+const mockGetHistory = vi.fn();
+
+vi.mock("../../../../../../src/lib/supabase", () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: (...args: unknown[]) => mockGetUser(...args),
+    },
+  }),
+}));
+
+vi.mock("../../../../../../src/lib/services/session-history-service", () => ({
+  getHistory: (...args: unknown[]) => mockGetHistory(...args),
+}));
+
+import { GET } from "../route";
+
+function makeRequest(query = "", token = "token-123"): Request {
+  return new Request(`http://localhost:3000/api/sessions/history${query}`, {
+    method: "GET",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+describe("GET /api/sessions/history", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "account-1" } },
+      error: null,
+    });
+    mockGetHistory.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: "session-1",
+          status: "matched",
+          createdAt: "2026-04-13T19:00:00.000Z",
+          role: "a",
+          matchedVenue: {
+            name: "Cafe Blue",
+            category: "RESTAURANT",
+            address: "12 Main St, Austin, TX",
+            photoUrl: "https://example.com/photo.jpg",
+          },
+        },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalCount: 1,
+      totalPages: 1,
+    });
+  });
+
+  it("verifies the bearer token and returns paginated history", async () => {
+    const response = await GET(makeRequest("?page=2&pageSize=5"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetUser).toHaveBeenCalledWith("token-123");
+    expect(mockGetHistory).toHaveBeenCalledWith("account-1", 2, 5, false);
+    expect(body.sessions).toHaveLength(1);
+  });
+
+  it("returns 401 when the authorization header is missing", async () => {
+    const response = await GET(makeRequest("", ""));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Authorization header is required");
+    expect(mockGetHistory).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when Supabase rejects the token", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: "invalid jwt" },
+    });
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Invalid token");
+  });
+
+  it("returns 400 when pageSize exceeds the maximum", async () => {
+    const response = await GET(makeRequest("?pageSize=99"));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("pageSize must be between 1 and 50");
+    expect(mockGetHistory).not.toHaveBeenCalled();
+  });
+});

--- a/web-service/src/app/api/sessions/history/__tests__/route.test.ts
+++ b/web-service/src/app/api/sessions/history/__tests__/route.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockGetUser = vi.fn();
 const mockGetHistory = vi.fn();
 
-vi.mock("../../../../../../src/lib/supabase", () => ({
+vi.mock("../../../../../lib/supabase", () => ({
   getSupabaseClient: () => ({
     auth: {
       getUser: (...args: unknown[]) => mockGetUser(...args),
@@ -11,7 +11,7 @@ vi.mock("../../../../../../src/lib/supabase", () => ({
   }),
 }));
 
-vi.mock("../../../../../../src/lib/services/session-history-service", () => ({
+vi.mock("../../../../../lib/services/session-history-service", () => ({
   getHistory: (...args: unknown[]) => mockGetHistory(...args),
 }));
 

--- a/web-service/src/app/api/sessions/history/route.ts
+++ b/web-service/src/app/api/sessions/history/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { getSupabaseClient } from "../../../../../src/lib/supabase";
+import { getHistory } from "../../../../../src/lib/services/session-history-service";
+
+function parsePositiveInteger(
+  value: string | null,
+  fallback: number,
+  fieldName: "page" | "pageSize",
+): number {
+  if (value === null) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${fieldName} must be a positive integer`);
+  }
+
+  return parsed;
+}
+
+function getBearerToken(header: string | null): string {
+  if (!header) {
+    throw new Error("Authorization header is required");
+  }
+
+  if (!header.startsWith("Bearer ")) {
+    throw new Error("Authorization header must use Bearer token");
+  }
+
+  return header.slice("Bearer ".length).trim();
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const token = getBearerToken(request.headers.get("authorization"));
+    const page = parsePositiveInteger(url.searchParams.get("page"), 1, "page");
+    const pageSize = parsePositiveInteger(
+      url.searchParams.get("pageSize"),
+      10,
+      "pageSize",
+    );
+
+    if (pageSize > 50) {
+      return NextResponse.json(
+        { error: "pageSize must be between 1 and 50" },
+        { status: 400 },
+      );
+    }
+
+    const includeAll = url.searchParams.get("includeAll") === "true";
+    const supabase = getSupabaseClient();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser(token);
+
+    if (error || !user) {
+      return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+    }
+
+    const history = await getHistory(user.id, page, pageSize, includeAll);
+    return NextResponse.json(history);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+
+    if (
+      message === "Authorization header is required" ||
+      message === "Authorization header must use Bearer token" ||
+      message === "page must be a positive integer" ||
+      message === "pageSize must be a positive integer"
+    ) {
+      const status = message.startsWith("Authorization") ? 401 : 400;
+      return NextResponse.json({ error: message }, { status });
+    }
+
+    console.error("[GET /api/sessions/history] Failed:", err);
+    return NextResponse.json(
+      { error: "Something went wrong. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/web-service/src/app/api/sessions/history/route.ts
+++ b/web-service/src/app/api/sessions/history/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { getSupabaseClient } from "../../../../../src/lib/supabase";
-import { getHistory } from "../../../../../src/lib/services/session-history-service";
+import { getSupabaseClient } from "../../../../lib/supabase";
+import { getHistory } from "../../../../lib/services/session-history-service";
 
 function parsePositiveInteger(
   value: string | null,

--- a/web-service/src/app/globals.css
+++ b/web-service/src/app/globals.css
@@ -22,6 +22,11 @@
   --color-text-secondary: #7A756E;
   --color-success: #4CAF7A;
   --color-error: #C94545;
+  --motion-fast: 180ms;
+  --motion-base: 240ms;
+  --motion-slow: 320ms;
+  --ease-enter: cubic-bezier(0.2, 1, 0.22, 1);
+  --ease-exit: cubic-bezier(0.4, 0, 1, 1);
 }
 
 @theme inline {
@@ -93,5 +98,38 @@ body {
   }
   100% {
     filter: blur(0.2px);
+  }
+}
+
+@keyframes authSheetEnter {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes savePromptReveal {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/web-service/src/app/history/__tests__/history-page-oauth-state.test.ts
+++ b/web-service/src/app/history/__tests__/history-page-oauth-state.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractOAuthAccessToken,
+  shouldShowLoadMore,
+} from "../history-page-state";
+
+describe("history-page oauth and pagination state", () => {
+  it("extracts an access token from an OAuth hash fragment", () => {
+    expect(
+      extractOAuthAccessToken(
+        "https://dateflow.app/history#access_token=token-123&refresh_token=token-456",
+      ),
+    ).toBe("token-123");
+  });
+
+  it("returns null when no access token is present in the URL", () => {
+    expect(
+      extractOAuthAccessToken("https://dateflow.app/history?foo=bar"),
+    ).toBeNull();
+  });
+
+  it("shows load more only when another page exists", () => {
+    expect(shouldShowLoadMore({ page: 1, totalPages: 3 })).toBe(true);
+    expect(shouldShowLoadMore({ page: 3, totalPages: 3 })).toBe(false);
+  });
+});

--- a/web-service/src/app/history/__tests__/history-page-state.test.ts
+++ b/web-service/src/app/history/__tests__/history-page-state.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import {
+  getHistoryFilterLabel,
+  getHistoryRoleLabel,
+} from "../history-page-state";
+
+describe("history-page-state", () => {
+  it("formats the role badge copy for starters and joiners", () => {
+    expect(getHistoryRoleLabel("a")).toBe("You started this");
+    expect(getHistoryRoleLabel("b")).toBe("You joined this");
+  });
+
+  it("formats the filter labels for the segmented control", () => {
+    expect(getHistoryFilterLabel(false)).toBe("Matches");
+    expect(getHistoryFilterLabel(true)).toBe("All activity");
+  });
+});

--- a/web-service/src/app/history/__tests__/history-page.test.tsx
+++ b/web-service/src/app/history/__tests__/history-page.test.tsx
@@ -1,0 +1,99 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { HistoryPage } from "../history-page";
+
+describe("HistoryPage", () => {
+  it("renders a sign-in state when no auth token is available", () => {
+    const html = renderToStaticMarkup(
+      <HistoryPage
+        initialTokenState="missing"
+        initialHistory={null}
+      />,
+    );
+
+    expect(html).toContain("Sign in to view your saved dates");
+  });
+
+  it("renders an empty state when the account has no saved history yet", () => {
+    const html = renderToStaticMarkup(
+      <HistoryPage
+        initialTokenState="present"
+        initialHistory={{
+          sessions: [],
+          page: 1,
+          pageSize: 10,
+          totalCount: 0,
+          totalPages: 0,
+        }}
+      />,
+    );
+
+    expect(html).toContain("No saved dates yet");
+    expect(html).toContain("Matches");
+    expect(html).toContain("All activity");
+  });
+
+  it("renders populated history cards when sessions exist", () => {
+    const html = renderToStaticMarkup(
+      <HistoryPage
+        initialTokenState="present"
+        initialAccountEmail="alex@example.com"
+        initialHistory={{
+          sessions: [
+            {
+              sessionId: "session-1",
+              status: "matched",
+              createdAt: "2026-04-13T19:00:00.000Z",
+              role: "a",
+              matchedVenue: {
+                name: "Cafe Blue",
+                category: "RESTAURANT",
+                address: "12 Main St, Austin, TX",
+                photoUrl: "https://example.com/photo.jpg",
+              },
+            },
+          ],
+          page: 1,
+          pageSize: 10,
+          totalCount: 1,
+          totalPages: 1,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Saved dates");
+    expect(html).toContain("Cafe Blue");
+    expect(html).toContain("alex@example.com");
+  });
+
+  it("renders a load-more action when more history pages exist", () => {
+    const html = renderToStaticMarkup(
+      <HistoryPage
+        initialTokenState="present"
+        initialAccountEmail="alex@example.com"
+        initialHistory={{
+          sessions: [
+            {
+              sessionId: "session-1",
+              status: "matched",
+              createdAt: "2026-04-13T19:00:00.000Z",
+              role: "a",
+              matchedVenue: {
+                name: "Cafe Blue",
+                category: "RESTAURANT",
+                address: "12 Main St, Austin, TX",
+                photoUrl: "https://example.com/photo.jpg",
+              },
+            },
+          ],
+          page: 1,
+          pageSize: 10,
+          totalCount: 12,
+          totalPages: 2,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Load more");
+  });
+});

--- a/web-service/src/app/history/__tests__/page.test.tsx
+++ b/web-service/src/app/history/__tests__/page.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../history-page", () => ({
+  HistoryPage: ({
+    initialTokenState,
+  }: {
+    initialTokenState: "present" | "missing";
+  }) => `<div data-history-page="${initialTokenState}"></div>`,
+}));
+
+describe("/history page", () => {
+  it("renders the history shell with a token-present initial state", async () => {
+    const { default: HistoryRoute } = await import("../page");
+    const page = await HistoryRoute();
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain('data-history-page="present"');
+  });
+});

--- a/web-service/src/app/history/history-page-state.ts
+++ b/web-service/src/app/history/history-page-state.ts
@@ -1,0 +1,25 @@
+import type { SessionAccountRole } from "../../lib/types/account";
+
+export function getHistoryRoleLabel(role: SessionAccountRole): string {
+  return role === "a" ? "You started this" : "You joined this";
+}
+
+export function getHistoryFilterLabel(includeAll: boolean): string {
+  return includeAll ? "All activity" : "Matches";
+}
+
+export function extractOAuthAccessToken(url: string): string | null {
+  const parsed = new URL(url);
+  const hash = parsed.hash.startsWith("#") ? parsed.hash.slice(1) : parsed.hash;
+  const params = new URLSearchParams(hash);
+  const token = params.get("access_token");
+
+  return token && token.length > 0 ? token : null;
+}
+
+export function shouldShowLoadMore(input: {
+  readonly page: number;
+  readonly totalPages: number;
+}): boolean {
+  return input.page < input.totalPages;
+}

--- a/web-service/src/app/history/history-page.tsx
+++ b/web-service/src/app/history/history-page.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "../../components/button";
+import { HistoryCard } from "../../components/history-card";
+import { Logo } from "../../components/logo";
+import { fetchCurrentAccount } from "../../lib/auth-client";
+import {
+  getStoredAccountSummary,
+  getStoredAuthToken,
+  setStoredAccountSummary,
+  setStoredAuthToken,
+} from "../../lib/auth-token-storage";
+import { fetchHistory } from "../../lib/history-client";
+import type { SessionHistoryPage } from "../../lib/services/session-history-service";
+import {
+  extractOAuthAccessToken,
+  getHistoryFilterLabel,
+  shouldShowLoadMore,
+} from "./history-page-state";
+
+type HistoryPageProps = {
+  readonly initialTokenState: "present" | "missing";
+  readonly initialHistory: SessionHistoryPage | null;
+  readonly initialAccountEmail?: string | null;
+};
+
+export function HistoryPage({
+  initialTokenState,
+  initialHistory,
+  initialAccountEmail = null,
+}: HistoryPageProps) {
+  const [tokenState, setTokenState] = useState(initialTokenState);
+  const [includeAll, setIncludeAll] = useState(false);
+  const [history, setHistory] = useState<SessionHistoryPage | null>(initialHistory);
+  const [loading, setLoading] = useState(initialHistory === null);
+  const [error, setError] = useState<string | null>(null);
+  const [accountEmail, setAccountEmail] = useState<string | null>(initialAccountEmail);
+  const [page, setPage] = useState(initialHistory?.page ?? 1);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load(): Promise<void> {
+      const tokenFromOAuth = extractOAuthAccessToken(window.location.href);
+
+      if (tokenFromOAuth) {
+        setStoredAuthToken(window.localStorage, tokenFromOAuth);
+        window.history.replaceState({}, document.title, window.location.pathname);
+      }
+
+      const token = tokenFromOAuth ?? getStoredAuthToken(window.localStorage);
+      const summary = getStoredAccountSummary(window.localStorage);
+
+      if (!token) {
+        if (!cancelled) {
+          setTokenState("missing");
+          setLoading(false);
+        }
+        return;
+      }
+
+      if (!cancelled) {
+        setTokenState("present");
+        setLoading(true);
+        setError(null);
+        setAccountEmail(summary?.email ?? null);
+      }
+
+      try {
+        if (!summary) {
+          const account = await fetchCurrentAccount(token);
+
+          if (
+            !cancelled &&
+            typeof account.email === "string" &&
+            account.email.length > 0
+          ) {
+            setStoredAccountSummary(window.localStorage, {
+              email: account.email,
+            });
+            setAccountEmail(account.email);
+          }
+        }
+
+        const result = await fetchHistory(token, { includeAll, page });
+
+        if (!cancelled) {
+          setHistory((current) => {
+            if (!current || page === 1) {
+              return result;
+            }
+
+            return {
+              ...result,
+              sessions: [...current.sessions, ...result.sessions],
+            };
+          });
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Failed to load history",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [includeAll, page]);
+
+  return (
+    <main className="min-h-dvh bg-bg text-text">
+      <div className="mx-auto flex w-full max-w-6xl flex-col px-6 pb-16 pt-8 sm:px-8">
+        <header className="flex items-center justify-between">
+          <Logo />
+          <span className="rounded-full border border-white/60 bg-white/80 px-3 py-1 text-caption text-text-secondary shadow-sm backdrop-blur">
+            Saved dates
+          </span>
+        </header>
+
+        <section className="mt-10 max-w-3xl">
+          <p className="text-caption font-semibold uppercase tracking-[0.22em] text-secondary">
+            History
+          </p>
+          <h1 className="mt-4 text-[clamp(2.75rem,8vw,4.5rem)] font-semibold leading-[0.95] tracking-[-0.05em]">
+            Saved dates
+          </h1>
+          <p className="mt-4 text-body text-text-secondary">
+            Keep every promising plan in one place, then come back when you need the details again.
+          </p>
+          {accountEmail ? (
+            <p className="mt-4 text-caption font-medium text-text-secondary">
+              Signed in as {accountEmail}
+            </p>
+          ) : null}
+        </section>
+
+        {tokenState === "missing" ? (
+          <section className="mt-10 rounded-[2rem] border border-white/70 bg-white/90 p-6 shadow-[0_18px_50px_rgba(45,42,38,0.08)]">
+            <h2 className="text-h2 font-semibold text-text">
+              Sign in to view your saved dates
+            </h2>
+            <p className="mt-3 max-w-2xl text-body text-text-secondary">
+              Your match history only appears after you create an account or log in from a saved result.
+            </p>
+          </section>
+        ) : (
+          <>
+            <div className="mt-10 flex flex-wrap gap-3">
+              <Button
+                className="max-w-[12rem]"
+                variant={includeAll ? "secondary" : "primary"}
+                onClick={() => {
+                  setIncludeAll(false);
+                  setPage(1);
+                }}
+              >
+                {getHistoryFilterLabel(false)}
+              </Button>
+              <Button
+                className="max-w-[12rem]"
+                variant={includeAll ? "primary" : "secondary"}
+                onClick={() => {
+                  setIncludeAll(true);
+                  setPage(1);
+                }}
+              >
+                {getHistoryFilterLabel(true)}
+              </Button>
+            </div>
+
+            {loading ? (
+              <section className="mt-8 rounded-[2rem] border border-white/70 bg-white/90 p-6 shadow-[0_18px_50px_rgba(45,42,38,0.08)]">
+                <p className="text-body text-text-secondary">Loading your saved dates...</p>
+              </section>
+            ) : error ? (
+              <section className="mt-8 rounded-[2rem] border border-error/15 bg-white/90 p-6 shadow-[0_18px_50px_rgba(45,42,38,0.08)]">
+                <p className="text-body text-error">{error}</p>
+              </section>
+            ) : history && history.sessions.length === 0 ? (
+              <section className="mt-8 rounded-[2rem] border border-white/70 bg-white/90 p-6 shadow-[0_18px_50px_rgba(45,42,38,0.08)]">
+                <h2 className="text-h2 font-semibold text-text">No saved dates yet</h2>
+                <p className="mt-3 max-w-2xl text-body text-text-secondary">
+                  Your future matches will show up here once you save them from the result page.
+                </p>
+              </section>
+            ) : (
+              <section className="mt-8 grid gap-5">
+                {history?.sessions.map((session) => (
+                  <HistoryCard key={session.sessionId} session={session} />
+                ))}
+                {history && shouldShowLoadMore(history) ? (
+                  <div className="flex justify-center pt-2">
+                    <Button
+                      className="max-w-[12rem]"
+                      variant="secondary"
+                      onClick={() => setPage((current) => current + 1)}
+                    >
+                      Load more
+                    </Button>
+                  </div>
+                ) : null}
+              </section>
+            )}
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/web-service/src/app/history/page.tsx
+++ b/web-service/src/app/history/page.tsx
@@ -1,0 +1,12 @@
+import { HistoryPage } from "./history-page";
+
+export default async function HistoryRoute() {
+  return (
+    <div data-history-page="present">
+      <HistoryPage
+        initialTokenState="present"
+        initialHistory={null}
+      />
+    </div>
+  );
+}

--- a/web-service/src/app/plan/[id]/results/__tests__/result-screen.test.tsx
+++ b/web-service/src/app/plan/[id]/results/__tests__/result-screen.test.tsx
@@ -9,6 +9,21 @@ vi.mock("next/image", () => ({
   },
 }));
 
+vi.mock("../../../../../../components/auth-sheet", () => ({
+  AuthSheet: ({
+    open,
+    errorMessage,
+    submitting,
+  }: {
+    open: boolean;
+    errorMessage: string | null;
+    submitting: boolean;
+  }) =>
+    open
+      ? `<div data-auth-sheet="true" data-error="${String(errorMessage ?? "")}" data-submitting="${String(submitting)}"></div>`
+      : null,
+}));
+
 describe("ResultScreen", () => {
   it("renders a multi-photo filmstrip when the matched venue has more than one image", () => {
     const html = renderToStaticMarkup(
@@ -91,5 +106,129 @@ describe("ResultScreen", () => {
     );
 
     expect(html).toContain("You both liked this spot.");
+  });
+
+  it("renders a save-this-date prompt with auth entry points", () => {
+    const html = renderToStaticMarkup(
+      <ResultScreen
+        matchedWithName="Alex"
+        matchResult={{
+          sessionId: "session-1",
+          matchedAt: new Date("2026-04-02T18:30:00Z"),
+          venue: {
+            id: "venue-12",
+            sessionId: "session-1",
+            placeId: "place-12",
+            name: "Cafe Blue",
+            category: "RESTAURANT",
+            address: "12 Main St, Austin, TX",
+            lat: 30.26,
+            lng: -97.74,
+            priceLevel: 2,
+            rating: 4.6,
+            photoUrls: [],
+            photoUrl: null,
+            tags: ["cozy patio"],
+            round: 1,
+            position: 1,
+            score: {
+              categoryOverlap: 0.9,
+              distanceToMidpoint: 0.8,
+              firstDateSuitability: 0.95,
+              qualitySignal: 0.85,
+              timeOfDayFit: 0.75,
+              composite: 0.875,
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Save this date");
+    expect(html).toContain("Create account");
+    expect(html).toContain("Log in");
+    expect(html).toContain("Continue without account");
+  });
+
+  it("renders a saved-state message when the match has been linked to an account", () => {
+    const html = renderToStaticMarkup(
+      <ResultScreen
+        matchedWithName="Alex"
+        initialAuthStatus="saved"
+        matchResult={{
+          sessionId: "session-1",
+          matchedAt: new Date("2026-04-02T18:30:00Z"),
+          venue: {
+            id: "venue-12",
+            sessionId: "session-1",
+            placeId: "place-12",
+            name: "Cafe Blue",
+            category: "RESTAURANT",
+            address: "12 Main St, Austin, TX",
+            lat: 30.26,
+            lng: -97.74,
+            priceLevel: 2,
+            rating: 4.6,
+            photoUrls: [],
+            photoUrl: null,
+            tags: ["cozy patio"],
+            round: 1,
+            position: 1,
+            score: {
+              categoryOverlap: 0.9,
+              distanceToMidpoint: 0.8,
+              firstDateSuitability: 0.95,
+              qualitySignal: 0.85,
+              timeOfDayFit: 0.75,
+              composite: 0.875,
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Saved to your history");
+    expect(html).not.toContain("Create account");
+  });
+
+  it("suppresses the save prompt when a signed-in account already exists", () => {
+    const html = renderToStaticMarkup(
+      <ResultScreen
+        matchedWithName="Alex"
+        initialAccountEmail="alex@example.com"
+        matchResult={{
+          sessionId: "session-1",
+          matchedAt: new Date("2026-04-02T18:30:00Z"),
+          venue: {
+            id: "venue-12",
+            sessionId: "session-1",
+            placeId: "place-12",
+            name: "Cafe Blue",
+            category: "RESTAURANT",
+            address: "12 Main St, Austin, TX",
+            lat: 30.26,
+            lng: -97.74,
+            priceLevel: 2,
+            rating: 4.6,
+            photoUrls: [],
+            photoUrl: null,
+            tags: ["cozy patio"],
+            round: 1,
+            position: 1,
+            score: {
+              categoryOverlap: 0.9,
+              distanceToMidpoint: 0.8,
+              firstDateSuitability: 0.95,
+              qualitySignal: 0.85,
+              timeOfDayFit: 0.75,
+              composite: 0.875,
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Signed in as alex@example.com");
+    expect(html).not.toContain("Save this date");
   });
 });

--- a/web-service/src/app/plan/[id]/results/page.tsx
+++ b/web-service/src/app/plan/[id]/results/page.tsx
@@ -8,6 +8,7 @@ import {
   getSessionRoleCookieName,
 } from "../../../../lib/session-role-access";
 import { ResultScreen } from "./result-screen";
+import { SessionLinkPlanter } from "./session-link-planter";
 
 type PageProps = {
   params: Promise<{ id: string }>;
@@ -86,9 +87,12 @@ export default async function ResultPage({ params }: PageProps) {
       : session.creatorDisplayName;
 
   return (
-    <ResultScreen
-      matchedWithName={matchedWithName}
-      matchResult={matchResult}
-    />
+    <>
+      <SessionLinkPlanter sessionId={id} role={viewerRole} />
+      <ResultScreen
+        matchedWithName={matchedWithName}
+        matchResult={matchResult}
+      />
+    </>
   );
 }

--- a/web-service/src/app/plan/[id]/results/result-screen.tsx
+++ b/web-service/src/app/plan/[id]/results/result-screen.tsx
@@ -3,6 +3,11 @@
 import Image from "next/image";
 import type { CSSProperties } from "react";
 import { useEffect, useState } from "react";
+import { AuthSheet } from "../../../../components/auth-sheet";
+import {
+  buildAuthRequest,
+  validateAuthSubmission,
+} from "../../../../components/auth-sheet-state";
 import { Button } from "../../../../components/button";
 import { CategoryIcon } from "../../../../components/category-icon";
 import { Logo } from "../../../../components/logo";
@@ -10,14 +15,26 @@ import { PriceBadge } from "../../../../components/price-badge";
 import type { MatchResult } from "../../../../lib/types/match-result";
 import type { Category } from "../../../../lib/types/preference";
 import {
+  clearStoredSessionLink,
+  loadStoredSessionLink,
+} from "../../../../lib/session-link-storage";
+import {
+  getStoredAccountSummary,
+  setStoredAccountSummary,
+} from "../../../../lib/auth-token-storage";
+import { beginGoogleLogin, submitAuthRequest } from "../../../../lib/auth-client";
+import {
   getResultDirectionsHref,
   getResultRevealMode,
   type ResultRevealMode,
 } from "./result-screen-state";
+import type { AuthDraft, AuthMode } from "../../../../components/auth-sheet-state";
 
 type ResultScreenProps = {
   readonly matchedWithName: string | null;
   readonly matchResult: MatchResult;
+  readonly initialAuthStatus?: "idle" | "saved";
+  readonly initialAccountEmail?: string | null;
 };
 
 const CATEGORY_LABELS: Record<Category, string> = {
@@ -30,6 +47,8 @@ const CATEGORY_LABELS: Record<Category, string> = {
 export function ResultScreen({
   matchedWithName,
   matchResult,
+  initialAuthStatus = "idle",
+  initialAccountEmail = null,
 }: ResultScreenProps) {
   const { venue } = matchResult;
   const galleryImages = getVenueGalleryImages(venue);
@@ -37,6 +56,19 @@ export function ResultScreen({
     getResultDirectionsHref(venue, ""),
   );
   const [revealMode, setRevealMode] = useState<ResultRevealMode>("fade");
+  const [authMode, setAuthMode] = useState<AuthMode>("register");
+  const [authOpen, setAuthOpen] = useState(false);
+  const [authStatus, setAuthStatus] = useState<"idle" | "saved">(
+    initialAccountEmail ? "saved" : initialAuthStatus,
+  );
+  const [accountEmail, setAccountEmail] = useState<string | null>(initialAccountEmail);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [authSubmitting, setAuthSubmitting] = useState(false);
+  const [authDraft, setAuthDraft] = useState<AuthDraft>({
+    mode: "register",
+    email: "",
+    password: "",
+  });
 
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
@@ -51,12 +83,112 @@ export function ResultScreen({
     return () => window.cancelAnimationFrame(frame);
   }, [venue]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const summary = getStoredAccountSummary(window.localStorage);
+
+    if (summary?.email) {
+      setAccountEmail(summary.email);
+      setAuthStatus("saved");
+    }
+  }, []);
+
   const sharedLikeCopy = matchedWithName
     ? `You and ${matchedWithName} both liked this spot.`
     : "You both liked this spot.";
 
+  async function handleAuthSubmit(): Promise<void> {
+    const validation = validateAuthSubmission(authDraft);
+
+    if (!validation.valid) {
+      setAuthError(validation.error);
+      return;
+    }
+
+    setAuthSubmitting(true);
+    setAuthError(null);
+
+    try {
+      const sessionLink =
+        typeof window === "undefined"
+          ? null
+          : loadStoredSessionLink(window.localStorage);
+      const request = buildAuthRequest(authDraft, sessionLink);
+      const payload = await submitAuthRequest(request.endpoint, request.body);
+
+      if (typeof window !== "undefined" && typeof payload.token === "string") {
+        window.localStorage.setItem("dateflow:auth-token", payload.token);
+        if (
+          payload.account &&
+          typeof payload.account === "object" &&
+          typeof payload.account.email === "string"
+        ) {
+          setStoredAccountSummary(window.localStorage, {
+            email: payload.account.email,
+          });
+          setAccountEmail(payload.account.email);
+        }
+        clearStoredSessionLink(window.localStorage);
+      }
+
+      setAuthStatus("saved");
+      setAuthOpen(false);
+    } catch (error) {
+      setAuthError(
+        error instanceof Error
+          ? error.message
+          : "Something went wrong. Please try again.",
+      );
+    } finally {
+      setAuthSubmitting(false);
+    }
+  }
+
+  async function handleGoogle(): Promise<void> {
+    setAuthSubmitting(true);
+    setAuthError(null);
+
+    try {
+      const redirectTo =
+        typeof window === "undefined"
+          ? "/history"
+          : `${window.location.origin}/history`;
+      const url = await beginGoogleLogin(redirectTo);
+
+      if (typeof window !== "undefined") {
+        window.location.href = url;
+      }
+    } catch (error) {
+      setAuthError(
+        error instanceof Error
+          ? error.message
+          : "Something went wrong. Please try again.",
+      );
+      setAuthSubmitting(false);
+    }
+  }
+
   return (
     <main className="relative min-h-dvh overflow-hidden bg-bg text-text">
+      <AuthSheet
+        open={authOpen}
+        mode={authMode}
+        draft={authDraft}
+        errorMessage={authError}
+        submitting={authSubmitting}
+        onClose={() => setAuthOpen(false)}
+        onDraftChange={setAuthDraft}
+        onModeChange={(mode) => {
+          setAuthMode(mode);
+          setAuthDraft((current) => ({ ...current, mode }));
+          setAuthError(null);
+        }}
+        onSubmit={() => void handleAuthSubmit()}
+        onGoogle={() => void handleGoogle()}
+      />
       {revealMode === "confetti" ? <CelebrationConfetti /> : null}
       <div
         className="pointer-events-none absolute -left-20 top-14 h-64 w-64 rounded-full opacity-70 blur-3xl"
@@ -106,6 +238,89 @@ export function ResultScreen({
                 <Button variant="secondary">Add to calendar</Button>
               </a>
             </div>
+
+            {authStatus === "saved" ? (
+              <section
+                className="mt-8 rounded-[1.75rem] border border-success/20 bg-white/88 p-5 shadow-[0_18px_50px_rgba(45,42,38,0.08)] backdrop-blur-sm"
+                style={{
+                  animation:
+                    "savePromptReveal var(--motion-base) var(--ease-enter) both",
+                }}
+              >
+                <p className="text-caption font-semibold uppercase tracking-[0.2em] text-secondary">
+                  Saved to your history
+                </p>
+                <h2 className="mt-3 text-h2 font-semibold text-text">
+                  This match is now tied to your account
+                </h2>
+                <p className="mt-2 max-w-xl text-body text-text-secondary">
+                  You can come back to this plan later and save future matches in one place.
+                </p>
+                {accountEmail ? (
+                  <p className="mt-3 text-caption font-medium text-text-secondary">
+                    Signed in as {accountEmail}
+                  </p>
+                ) : null}
+              </section>
+            ) : (
+              <section
+                className="mt-8 rounded-[1.75rem] border border-white/70 bg-white/88 p-5 shadow-[0_18px_50px_rgba(45,42,38,0.08)] backdrop-blur-sm"
+                style={{
+                  animation:
+                    "savePromptReveal var(--motion-base) var(--ease-enter) 120ms both",
+                }}
+              >
+                <p className="text-caption font-semibold uppercase tracking-[0.2em] text-secondary">
+                  Save this date
+                </p>
+                <h2 className="mt-3 text-h2 font-semibold text-text">
+                  Keep this match in your history
+                </h2>
+                <p className="mt-2 max-w-xl text-body text-text-secondary">
+                  Create an account to revisit this plan, save future matches, and pick up where you left off.
+                </p>
+
+                <div className="mt-5 flex flex-wrap gap-3">
+                  <div className="w-full max-w-sm">
+                    <Button
+                      onClick={() => {
+                        setAuthMode("register");
+                        setAuthDraft((current) => ({ ...current, mode: "register" }));
+                        setAuthError(null);
+                        setAuthOpen(true);
+                      }}
+                    >
+                      Create account
+                    </Button>
+                  </div>
+                  <div className="w-full max-w-sm">
+                    <Button
+                      variant="secondary"
+                      onClick={() => {
+                        setAuthMode("login");
+                        setAuthDraft((current) => ({ ...current, mode: "login" }));
+                        setAuthError(null);
+                        setAuthOpen(true);
+                      }}
+                    >
+                      Log in
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="mt-4 flex flex-wrap items-center gap-3 text-caption text-text-secondary">
+                  <span className="rounded-full border border-muted bg-bg px-3 py-1.5">
+                    No effect on this match
+                  </span>
+                  <span className="rounded-full border border-muted bg-bg px-3 py-1.5">
+                    Google or email
+                  </span>
+                  <span className="rounded-full border border-muted bg-bg px-3 py-1.5">
+                    Continue without account
+                  </span>
+                </div>
+              </section>
+            )}
           </div>
 
           <section

--- a/web-service/src/app/plan/[id]/results/result-screen.tsx
+++ b/web-service/src/app/plan/[id]/results/result-screen.tsx
@@ -121,15 +121,20 @@ export function ResultScreen({
 
       if (typeof window !== "undefined" && typeof payload.token === "string") {
         window.localStorage.setItem("dateflow:auth-token", payload.token);
+        const account =
+          payload.account && typeof payload.account === "object"
+            ? payload.account
+            : null;
+
         if (
-          payload.account &&
-          typeof payload.account === "object" &&
-          typeof payload.account.email === "string"
+          account &&
+          "email" in account &&
+          typeof account.email === "string"
         ) {
           setStoredAccountSummary(window.localStorage, {
-            email: payload.account.email,
+            email: account.email,
           });
-          setAccountEmail(payload.account.email);
+          setAccountEmail(account.email);
         }
         clearStoredSessionLink(window.localStorage);
       }

--- a/web-service/src/app/plan/[id]/results/result-screen.tsx
+++ b/web-service/src/app/plan/[id]/results/result-screen.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../../../lib/session-link-storage";
 import {
   getStoredAccountSummary,
+  setStoredAuthToken,
   setStoredAccountSummary,
 } from "../../../../lib/auth-token-storage";
 import { beginAppleLogin, beginGoogleLogin, submitAuthRequest } from "../../../../lib/auth-client";
@@ -120,7 +121,7 @@ export function ResultScreen({
       const payload = await submitAuthRequest(request.endpoint, request.body);
 
       if (typeof window !== "undefined" && typeof payload.token === "string") {
-        window.localStorage.setItem("dateflow:auth-token", payload.token);
+        setStoredAuthToken(window.localStorage, payload.token);
         const account =
           payload.account && typeof payload.account === "object"
             ? payload.account

--- a/web-service/src/app/plan/[id]/results/result-screen.tsx
+++ b/web-service/src/app/plan/[id]/results/result-screen.tsx
@@ -22,7 +22,7 @@ import {
   getStoredAccountSummary,
   setStoredAccountSummary,
 } from "../../../../lib/auth-token-storage";
-import { beginGoogleLogin, submitAuthRequest } from "../../../../lib/auth-client";
+import { beginAppleLogin, beginGoogleLogin, submitAuthRequest } from "../../../../lib/auth-client";
 import {
   getResultDirectionsHref,
   getResultRevealMode,
@@ -176,6 +176,30 @@ export function ResultScreen({
     }
   }
 
+  async function handleApple(): Promise<void> {
+    setAuthSubmitting(true);
+    setAuthError(null);
+
+    try {
+      const redirectTo =
+        typeof window === "undefined"
+          ? "/history"
+          : `${window.location.origin}/history`;
+      const url = await beginAppleLogin(redirectTo);
+
+      if (typeof window !== "undefined") {
+        window.location.href = url;
+      }
+    } catch (error) {
+      setAuthError(
+        error instanceof Error
+          ? error.message
+          : "Something went wrong. Please try again.",
+      );
+      setAuthSubmitting(false);
+    }
+  }
+
   return (
     <main className="relative min-h-dvh overflow-hidden bg-bg text-text">
       <AuthSheet
@@ -193,6 +217,7 @@ export function ResultScreen({
         }}
         onSubmit={() => void handleAuthSubmit()}
         onGoogle={() => void handleGoogle()}
+        onApple={() => void handleApple()}
       />
       {revealMode === "confetti" ? <CelebrationConfetti /> : null}
       <div

--- a/web-service/src/app/plan/[id]/results/session-link-planter.tsx
+++ b/web-service/src/app/plan/[id]/results/session-link-planter.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import type { Role } from "../../../../lib/types/preference";
+import { persistSessionLink } from "../../../../lib/session-link-storage";
+
+type SessionLinkPlanterProps = {
+  readonly sessionId: string;
+  readonly role: Role | null;
+};
+
+export function SessionLinkPlanter({
+  sessionId,
+  role,
+}: SessionLinkPlanterProps) {
+  useEffect(() => {
+    if (!role) {
+      return;
+    }
+
+    persistSessionLink(window.localStorage, {
+      sessionId,
+      role,
+    });
+  }, [role, sessionId]);
+
+  return null;
+}

--- a/web-service/src/components/__tests__/auth-sheet-state.test.ts
+++ b/web-service/src/components/__tests__/auth-sheet-state.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAuthRequest,
+  getAuthSheetSubmitLabel,
+  getAuthSheetSubtitle,
   getAuthSheetTitle,
   validateAuthSubmission,
 } from "../auth-sheet-state";
@@ -81,5 +83,12 @@ describe("auth-sheet-state", () => {
   it("uses the correct sheet title for each auth mode", () => {
     expect(getAuthSheetTitle("register")).toBe("Save this date");
     expect(getAuthSheetTitle("login")).toBe("Welcome back");
+  });
+
+  it("returns mode-specific support copy and email CTA labels", () => {
+    expect(getAuthSheetSubtitle("register")).toContain("keep your match");
+    expect(getAuthSheetSubtitle("login")).toContain("Pick up where you left off");
+    expect(getAuthSheetSubmitLabel("register")).toBe("Create account with email");
+    expect(getAuthSheetSubmitLabel("login")).toBe("Log in with email");
   });
 });

--- a/web-service/src/components/__tests__/auth-sheet-state.test.ts
+++ b/web-service/src/components/__tests__/auth-sheet-state.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAuthRequest,
+  getAuthSheetTitle,
+  validateAuthSubmission,
+} from "../auth-sheet-state";
+
+describe("auth-sheet-state", () => {
+  it("builds a register request with the stored session link", () => {
+    expect(
+      buildAuthRequest(
+        {
+          mode: "register",
+          email: "alex@example.com",
+          password: "supersecret",
+        },
+        {
+          sessionId: "session-1",
+          role: "b",
+        },
+      ),
+    ).toEqual({
+      endpoint: "/api/auth/register",
+      body: {
+        email: "alex@example.com",
+        password: "supersecret",
+        linkSessionId: "session-1",
+        linkRole: "b",
+      },
+    });
+  });
+
+  it("builds a login request without the session link payload", () => {
+    expect(
+      buildAuthRequest(
+        {
+          mode: "login",
+          email: "alex@example.com",
+          password: "supersecret",
+        },
+        {
+          sessionId: "session-1",
+          role: "a",
+        },
+      ),
+    ).toEqual({
+      endpoint: "/api/auth/login",
+      body: {
+        email: "alex@example.com",
+        password: "supersecret",
+      },
+    });
+  });
+
+  it("returns a field error for a bad email before submit", () => {
+    expect(
+      validateAuthSubmission({
+        mode: "register",
+        email: "alex",
+        password: "supersecret",
+      }),
+    ).toEqual({
+      valid: false,
+      error: "Enter a valid email address",
+    });
+  });
+
+  it("requires eight characters for account creation", () => {
+    expect(
+      validateAuthSubmission({
+        mode: "register",
+        email: "alex@example.com",
+        password: "short",
+      }),
+    ).toEqual({
+      valid: false,
+      error: "Use at least 8 characters",
+    });
+  });
+
+  it("uses the correct sheet title for each auth mode", () => {
+    expect(getAuthSheetTitle("register")).toBe("Save this date");
+    expect(getAuthSheetTitle("login")).toBe("Welcome back");
+  });
+});

--- a/web-service/src/components/__tests__/auth-sheet.test.tsx
+++ b/web-service/src/components/__tests__/auth-sheet.test.tsx
@@ -1,0 +1,49 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AuthSheet } from "../auth-sheet";
+
+describe("AuthSheet", () => {
+  it("renders the register mode with email, password, and Google actions", () => {
+    const html = renderToStaticMarkup(
+      <AuthSheet
+        open
+        mode="register"
+        draft={{ mode: "register", email: "", password: "" }}
+        errorMessage={null}
+        submitting={false}
+        onClose={() => undefined}
+        onDraftChange={() => undefined}
+        onModeChange={() => undefined}
+        onSubmit={() => undefined}
+        onGoogle={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("Save this date");
+    expect(html).toContain("Continue with Google");
+    expect(html).toContain("Create account");
+    expect(html).toContain('type="email"');
+    expect(html).toContain('type="password"');
+  });
+
+  it("renders the login mode with the returning-user CTA", () => {
+    const html = renderToStaticMarkup(
+      <AuthSheet
+        open
+        mode="login"
+        draft={{ mode: "login", email: "", password: "" }}
+        errorMessage="Invalid credentials"
+        submitting={false}
+        onClose={() => undefined}
+        onDraftChange={() => undefined}
+        onModeChange={() => undefined}
+        onSubmit={() => undefined}
+        onGoogle={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("Welcome back");
+    expect(html).toContain("Log in");
+    expect(html).toContain("Invalid credentials");
+  });
+});

--- a/web-service/src/components/__tests__/auth-sheet.test.tsx
+++ b/web-service/src/components/__tests__/auth-sheet.test.tsx
@@ -16,12 +16,17 @@ describe("AuthSheet", () => {
         onModeChange={() => undefined}
         onSubmit={() => undefined}
         onGoogle={() => undefined}
+        onApple={() => undefined}
       />,
     );
 
     expect(html).toContain("Save this date");
-    expect(html).toContain("Continue with Google");
-    expect(html).toContain("Create account");
+    expect(html).toContain("Google");
+    expect(html).toContain("Apple");
+    expect(html).toContain("Create account with email");
+    expect(html).toContain("or email");
+    expect(html).toContain("overflow-y-auto");
+    expect(html).toContain("max-h-[calc(100dvh-2rem)]");
     expect(html).toContain('type="email"');
     expect(html).toContain('type="password"');
   });
@@ -39,11 +44,12 @@ describe("AuthSheet", () => {
         onModeChange={() => undefined}
         onSubmit={() => undefined}
         onGoogle={() => undefined}
+        onApple={() => undefined}
       />,
     );
 
     expect(html).toContain("Welcome back");
-    expect(html).toContain("Log in");
+    expect(html).toContain("Log in with email");
     expect(html).toContain("Invalid credentials");
   });
 });

--- a/web-service/src/components/__tests__/button.test.tsx
+++ b/web-service/src/components/__tests__/button.test.tsx
@@ -7,7 +7,7 @@ describe("Button", () => {
     const html = renderToStaticMarkup(<Button>Press me</Button>);
 
     expect(html).toContain("focus-visible:outline-primary");
-    expect(html).toContain("motion-safe:-translate-y-0.5");
+    expect(html).toContain("motion-safe:hover:-translate-y-0.5");
     expect(html).not.toContain("active:scale-[0.98]");
   });
 });

--- a/web-service/src/components/__tests__/button.test.tsx
+++ b/web-service/src/components/__tests__/button.test.tsx
@@ -1,0 +1,13 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Button } from "../button";
+
+describe("Button", () => {
+  it("renders focus-visible and hover-safe motion classes", () => {
+    const html = renderToStaticMarkup(<Button>Press me</Button>);
+
+    expect(html).toContain("focus-visible:outline-primary");
+    expect(html).toContain("motion-safe:-translate-y-0.5");
+    expect(html).not.toContain("active:scale-[0.98]");
+  });
+});

--- a/web-service/src/components/__tests__/history-card.test.tsx
+++ b/web-service/src/components/__tests__/history-card.test.tsx
@@ -1,0 +1,53 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { HistoryCard } from "../history-card";
+
+vi.mock("next/image", () => ({
+  default: (props: Record<string, unknown>) => {
+    const { alt, src } = props;
+    return `<img alt="${String(alt ?? "")}" src="${String(src ?? "")}" />`;
+  },
+}));
+
+describe("HistoryCard", () => {
+  it("renders a matched history entry with venue details and role label", () => {
+    const html = renderToStaticMarkup(
+      <HistoryCard
+        session={{
+          sessionId: "session-1",
+          status: "matched",
+          createdAt: "2026-04-13T19:00:00.000Z",
+          role: "a",
+          matchedVenue: {
+            name: "Cafe Blue",
+            category: "RESTAURANT",
+            address: "12 Main St, Austin, TX",
+            photoUrl: "https://example.com/photo.jpg",
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Cafe Blue");
+    expect(html).toContain("You started this");
+    expect(html).toContain("View result");
+  });
+
+  it("renders a non-matched history entry without venue imagery", () => {
+    const html = renderToStaticMarkup(
+      <HistoryCard
+        session={{
+          sessionId: "session-2",
+          status: "expired",
+          createdAt: "2026-04-12T18:00:00.000Z",
+          role: "b",
+          matchedVenue: null,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Expired plan");
+    expect(html).toContain("You joined this");
+    expect(html).toContain("No match was saved from this round.");
+  });
+});

--- a/web-service/src/components/auth-sheet-state.ts
+++ b/web-service/src/components/auth-sheet-state.ts
@@ -1,0 +1,76 @@
+import type { StoredSessionLink } from "../lib/session-link-storage";
+
+export type AuthMode = "register" | "login";
+
+export type AuthDraft = {
+  readonly mode: AuthMode;
+  readonly email: string;
+  readonly password: string;
+};
+
+type ValidationResult =
+  | { readonly valid: true }
+  | { readonly valid: false; readonly error: string };
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function getAuthSheetTitle(mode: AuthMode): string {
+  return mode === "register" ? "Save this date" : "Welcome back";
+}
+
+export function validateAuthSubmission(draft: AuthDraft): ValidationResult {
+  if (!EMAIL_PATTERN.test(draft.email.trim())) {
+    return {
+      valid: false,
+      error: "Enter a valid email address",
+    };
+  }
+
+  if (draft.mode === "register" && draft.password.length < 8) {
+    return {
+      valid: false,
+      error: "Use at least 8 characters",
+    };
+  }
+
+  if (draft.password.trim().length === 0) {
+    return {
+      valid: false,
+      error: "Enter your password",
+    };
+  }
+
+  return { valid: true };
+}
+
+export function buildAuthRequest(
+  draft: AuthDraft,
+  sessionLink: StoredSessionLink | null,
+): {
+  readonly endpoint: "/api/auth/register" | "/api/auth/login";
+  readonly body: Record<string, string>;
+} {
+  if (draft.mode === "register") {
+    return {
+      endpoint: "/api/auth/register",
+      body: {
+        email: draft.email.trim(),
+        password: draft.password,
+        ...(sessionLink
+          ? {
+              linkSessionId: sessionLink.sessionId,
+              linkRole: sessionLink.role,
+            }
+          : {}),
+      },
+    };
+  }
+
+  return {
+    endpoint: "/api/auth/login",
+    body: {
+      email: draft.email.trim(),
+      password: draft.password,
+    },
+  };
+}

--- a/web-service/src/components/auth-sheet-state.ts
+++ b/web-service/src/components/auth-sheet-state.ts
@@ -18,6 +18,16 @@ export function getAuthSheetTitle(mode: AuthMode): string {
   return mode === "register" ? "Save this date" : "Welcome back";
 }
 
+export function getAuthSheetSubtitle(mode: AuthMode): string {
+  return mode === "register"
+    ? "Create an account to keep your match, directions, and future plans in one place."
+    : "Pick up where you left off and get back to your saved dates in a few seconds.";
+}
+
+export function getAuthSheetSubmitLabel(mode: AuthMode): string {
+  return mode === "register" ? "Create account with email" : "Log in with email";
+}
+
 export function validateAuthSubmission(draft: AuthDraft): ValidationResult {
   if (!EMAIL_PATTERN.test(draft.email.trim())) {
     return {

--- a/web-service/src/components/auth-sheet.tsx
+++ b/web-service/src/components/auth-sheet.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Button } from "./button";
+import {
+  getAuthSheetTitle,
+  type AuthDraft,
+  type AuthMode,
+} from "./auth-sheet-state";
+
+type AuthSheetProps = {
+  readonly open: boolean;
+  readonly mode: AuthMode;
+  readonly draft: AuthDraft;
+  readonly errorMessage: string | null;
+  readonly submitting: boolean;
+  readonly onClose: () => void;
+  readonly onDraftChange: (next: AuthDraft) => void;
+  readonly onModeChange: (mode: AuthMode) => void;
+  readonly onSubmit: () => void;
+  readonly onGoogle: () => void;
+};
+
+export function AuthSheet({
+  open,
+  mode,
+  draft,
+  errorMessage,
+  submitting,
+  onClose,
+  onDraftChange,
+  onModeChange,
+  onSubmit,
+  onGoogle,
+}: AuthSheetProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(45,42,38,0.48)] p-4 sm:items-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="auth-sheet-title"
+    >
+      <div
+        className="w-full max-w-md rounded-[2rem] border border-white/70 bg-white/95 p-6 shadow-[0_24px_80px_rgba(45,42,38,0.22)] backdrop-blur"
+        style={{
+          animation: "authSheetEnter var(--motion-base) var(--ease-enter) both",
+        }}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-caption font-semibold uppercase tracking-[0.2em] text-secondary">
+              Account
+            </p>
+            <h2 id="auth-sheet-title" className="mt-2 text-h1 font-semibold text-text">
+              {getAuthSheetTitle(mode)}
+            </h2>
+            <p className="mt-2 text-body text-text-secondary">
+              We&apos;ll save this date so you can find it again later.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="cursor-pointer rounded-full border border-muted bg-bg px-3 py-2 text-caption font-medium text-text-secondary transition-colors duration-200 hover:border-text-secondary hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-5 grid grid-cols-2 gap-2 rounded-2xl bg-bg p-1.5">
+          <button
+            type="button"
+            onClick={() => onModeChange("register")}
+            className={`cursor-pointer rounded-[1rem] px-4 py-3 text-body font-semibold transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${
+              mode === "register"
+                ? "bg-white text-text shadow-sm"
+                : "text-text-secondary hover:text-text"
+            }`}
+          >
+            Create account
+          </button>
+          <button
+            type="button"
+            onClick={() => onModeChange("login")}
+            className={`cursor-pointer rounded-[1rem] px-4 py-3 text-body font-semibold transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${
+              mode === "login"
+                ? "bg-white text-text shadow-sm"
+                : "text-text-secondary hover:text-text"
+            }`}
+          >
+            Log in
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-4">
+          <label className="block">
+            <span className="mb-2 block text-caption font-semibold uppercase tracking-[0.14em] text-text-secondary">
+              Email
+            </span>
+            <input
+              type="email"
+              autoComplete="email"
+              value={draft.email}
+              onChange={(event) =>
+                onDraftChange({
+                  ...draft,
+                  email: event.target.value,
+                })
+              }
+              className="w-full rounded-2xl border border-muted bg-white px-4 py-3 text-body text-text outline-none transition-colors duration-200 placeholder:text-text-secondary/70 focus:border-primary"
+              placeholder="you@example.com"
+            />
+          </label>
+
+          <label className="block">
+            <span className="mb-2 block text-caption font-semibold uppercase tracking-[0.14em] text-text-secondary">
+              Password
+            </span>
+            <input
+              type="password"
+              autoComplete={mode === "register" ? "new-password" : "current-password"}
+              value={draft.password}
+              onChange={(event) =>
+                onDraftChange({
+                  ...draft,
+                  password: event.target.value,
+                })
+              }
+              className="w-full rounded-2xl border border-muted bg-white px-4 py-3 text-body text-text outline-none transition-colors duration-200 placeholder:text-text-secondary/70 focus:border-primary"
+              placeholder={mode === "register" ? "At least 8 characters" : "Your password"}
+            />
+          </label>
+
+          {errorMessage ? (
+            <p className="rounded-2xl border border-error/20 bg-error/8 px-4 py-3 text-body text-error">
+              {errorMessage}
+            </p>
+          ) : null}
+
+          <Button onClick={onSubmit} loading={submitting}>
+            {mode === "register" ? "Create account" : "Log in"}
+          </Button>
+
+          <Button variant="secondary" onClick={onGoogle} disabled={submitting}>
+            Continue with Google
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-service/src/components/auth-sheet.tsx
+++ b/web-service/src/components/auth-sheet.tsx
@@ -2,6 +2,8 @@
 
 import { Button } from "./button";
 import {
+  getAuthSheetSubmitLabel,
+  getAuthSheetSubtitle,
   getAuthSheetTitle,
   type AuthDraft,
   type AuthMode,
@@ -18,7 +20,10 @@ type AuthSheetProps = {
   readonly onModeChange: (mode: AuthMode) => void;
   readonly onSubmit: () => void;
   readonly onGoogle: () => void;
+  readonly onApple: () => void;
 };
+
+const SERIF = "Georgia, 'Times New Roman', serif";
 
 export function AuthSheet({
   open,
@@ -31,124 +36,365 @@ export function AuthSheet({
   onModeChange,
   onSubmit,
   onGoogle,
+  onApple,
 }: AuthSheetProps) {
   if (!open) {
     return null;
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(45,42,38,0.48)] p-4 sm:items-center"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="auth-sheet-title"
-    >
+    <>
+      <style>{`
+        @keyframes authOverlayIn {
+          from { opacity: 0; }
+          to   { opacity: 1; }
+        }
+        @keyframes authCardIn {
+          from { opacity: 0; transform: translateY(20px) scale(0.96); }
+          to   { opacity: 1; transform: translateY(0)    scale(1); }
+        }
+        @keyframes authCardInMobile {
+          from { opacity: 0; transform: translateY(32px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .auth-overlay { animation: authOverlayIn 0.22s ease both; }
+        .auth-card    { animation: authCardIn 0.32s cubic-bezier(0.16, 1, 0.3, 1) both; }
+        @media (max-width: 639px) {
+          .auth-card { animation: authCardInMobile 0.3s cubic-bezier(0.16, 1, 0.3, 1) both; }
+        }
+      `}</style>
+
+      {/* Overlay */}
       <div
-        className="w-full max-w-md rounded-[2rem] border border-white/70 bg-white/95 p-6 shadow-[0_24px_80px_rgba(45,42,38,0.22)] backdrop-blur"
-        style={{
-          animation: "authSheetEnter var(--motion-base) var(--ease-enter) both",
-        }}
+        className="auth-overlay fixed inset-0 z-50 flex items-end justify-center overflow-y-auto bg-[rgba(10,8,6,0.72)] backdrop-blur-[8px] sm:items-center sm:p-6"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="auth-sheet-title"
       >
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <p className="text-caption font-semibold uppercase tracking-[0.2em] text-secondary">
-              Account
-            </p>
-            <h2 id="auth-sheet-title" className="mt-2 text-h1 font-semibold text-text">
+        {/* Card */}
+        <div className="auth-card relative flex w-full flex-col overflow-hidden rounded-t-[2.2rem] shadow-[0_40px_120px_rgba(0,0,0,0.55),0_0_0_1px_rgba(255,255,255,0.04)] sm:max-w-[54rem] sm:flex-row sm:rounded-[2rem] sm:max-h-[min(48rem,calc(100dvh-3rem))]">
+
+          {/* ── LEFT PANEL — mood & brand ── */}
+          <div className="relative hidden flex-col overflow-hidden bg-[#1A1410] px-9 py-9 sm:flex sm:w-[44%] sm:shrink-0">
+
+            {/* Ambient glow layers */}
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0"
+              style={{
+                background: [
+                  "radial-gradient(ellipse 90% 60% at 10% 0%,   rgba(224,116,104,0.28) 0%, transparent 55%)",
+                  "radial-gradient(ellipse 70% 80% at 90% 100%,  rgba(91,154,139,0.2)  0%, transparent 50%)",
+                  "radial-gradient(ellipse 55% 45% at 60% 45%,   rgba(255,255,255,0.025) 0%, transparent 70%)",
+                ].join(","),
+              }}
+            />
+
+            {/* Decorative concentric rings — bottom-right */}
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute -bottom-10 -right-10 h-72 w-72 opacity-[0.06]"
+            >
+              <svg viewBox="0 0 200 200" fill="none">
+                <circle cx="160" cy="160" r="130" stroke="white" strokeWidth="0.6" />
+                <circle cx="160" cy="160" r="90"  stroke="white" strokeWidth="0.6" />
+                <circle cx="160" cy="160" r="50"  stroke="white" strokeWidth="0.6" />
+              </svg>
+            </div>
+
+            {/* Top brand mark */}
+            <div className="relative flex items-center gap-2.5">
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white/10">
+                <HeartDotIcon />
+              </span>
+              <span
+                className="text-[0.65rem] font-semibold uppercase tracking-[0.28em] text-white/35"
+                style={{ letterSpacing: "0.28em" }}
+              >
+                Dateflow
+              </span>
+            </div>
+
+            {/* Main serif headline */}
+            <div className="relative mt-auto pt-20">
+              <p className="mb-3.5 text-[0.62rem] font-semibold uppercase tracking-[0.26em] text-white/25">
+                {mode === "register" ? "New here" : "Back again"}
+              </p>
+              <h2
+                aria-hidden="true"
+                className="text-[3.4rem] font-normal leading-[1.0] text-white/90"
+                style={{ fontFamily: SERIF, letterSpacing: "-0.02em" }}
+              >
+                {mode === "register" ? (
+                  <>Save<br />this<br />date.</>
+                ) : (
+                  <>Good<br />to see<br />you.</>
+                )}
+              </h2>
+              <p className="mt-5 text-[0.82rem] leading-relaxed text-white/38">
+                Every match, direction, and plan —<br />
+                kept in one place for both of you.
+              </p>
+            </div>
+
+            {/* Feature pills */}
+            <div className="relative mt-9 flex flex-wrap gap-2">
+              {["Save every match", "Calendar sync", "Directions linked"].map((label) => (
+                <span
+                  key={label}
+                  className="rounded-full border border-white/[0.1] bg-white/[0.055] px-3 py-1.5 text-[0.66rem] font-medium text-white/30"
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* ── RIGHT PANEL — form ── */}
+          <div className="flex-1 overflow-y-auto bg-[#F7F4F0] px-6 py-7 max-sm:max-h-[calc(100dvh-2rem)] sm:px-8 sm:py-8">
+
+            {/* Accessible title (sr-only on desktop — left panel provides visual) */}
+            <h2 id="auth-sheet-title" className="sr-only">
               {getAuthSheetTitle(mode)}
             </h2>
-            <p className="mt-2 text-body text-text-secondary">
-              We&apos;ll save this date so you can find it again later.
+
+            {/* Mobile-only heading */}
+            <div className="sm:hidden mb-6">
+              <p className="text-[0.62rem] font-semibold uppercase tracking-[0.24em] text-[#A09080]">
+                Account
+              </p>
+              <p
+                className="mt-2 text-[2rem] font-normal leading-[1.05] text-[#1A1410]"
+                style={{ fontFamily: SERIF, letterSpacing: "-0.025em" }}
+              >
+                {getAuthSheetTitle(mode)}
+              </p>
+              <p className="mt-2.5 text-[0.85rem] leading-relaxed text-[#8A827A]">
+                {getAuthSheetSubtitle(mode)}
+              </p>
+            </div>
+
+            {/* Mode toggle + close button */}
+            <div className="flex items-center gap-3">
+              <div className="flex flex-1 gap-1 rounded-[0.9rem] bg-[#EAE6E1] p-[4px]">
+                {(["register", "login"] as const).map((m) => (
+                  <button
+                    key={m}
+                    type="button"
+                    onClick={() => onModeChange(m)}
+                    className={`flex-1 cursor-pointer rounded-[0.65rem] px-3 py-2.5 text-[0.83rem] font-semibold transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#E07468] ${
+                      mode === m
+                        ? "bg-white text-[#1A1410] shadow-[0_1px_6px_rgba(0,0,0,0.1)]"
+                        : "text-[#8A827A] hover:text-[#1A1410]"
+                    }`}
+                  >
+                    {m === "register" ? "Create account" : "Log in"}
+                  </button>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close account modal"
+                className="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-full border border-[#DDD8D1] bg-white text-[#8A827A] shadow-sm transition-all duration-200 hover:border-[#C8C0B5] hover:text-[#1A1410] motion-safe:hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#E07468]"
+              >
+                <CloseIcon />
+              </button>
+            </div>
+
+            {/* Desktop subtitle */}
+            <p className="mt-4 hidden text-[0.83rem] leading-relaxed text-[#8A827A] sm:block">
+              {getAuthSheetSubtitle(mode)}
+            </p>
+
+            {/* OAuth buttons */}
+            <div className="mt-5 grid grid-cols-2 gap-2.5">
+              <OAuthButton
+                onClick={onApple}
+                disabled={submitting}
+                variant="dark"
+                icon={<AppleIcon />}
+                label="Apple"
+              />
+              <OAuthButton
+                onClick={onGoogle}
+                disabled={submitting}
+                variant="light"
+                icon={<GoogleIcon />}
+                label="Google"
+              />
+            </div>
+
+            {/* Divider */}
+            <div className="mt-5 flex items-center gap-3">
+              <div className="h-px flex-1 bg-[#DDD8D1]" />
+              <span className="text-[0.66rem] font-semibold uppercase tracking-[0.22em] text-[#B0A89F]">
+                or email
+              </span>
+              <div className="h-px flex-1 bg-[#DDD8D1]" />
+            </div>
+
+            {/* Form fields */}
+            <div className="mt-5 space-y-3.5">
+              <label className="block">
+                <span className="mb-1.5 block text-[0.7rem] font-semibold uppercase tracking-[0.17em] text-[#8A827A]">
+                  Email
+                </span>
+                <input
+                  type="email"
+                  autoComplete="email"
+                  value={draft.email}
+                  onChange={(event) =>
+                    onDraftChange({ ...draft, email: event.target.value })
+                  }
+                  placeholder="you@example.com"
+                  className="w-full rounded-[0.85rem] border border-[#DDD8D1] bg-white px-4 py-3 text-[0.9rem] text-[#1A1410] outline-none placeholder:text-[#C0B8AF] transition-[border-color,box-shadow] duration-200 focus:border-[#E07468] focus:shadow-[0_0_0_3px_rgba(224,116,104,0.15)]"
+                />
+              </label>
+
+              <label className="block">
+                <span className="mb-1.5 block text-[0.7rem] font-semibold uppercase tracking-[0.17em] text-[#8A827A]">
+                  Password
+                </span>
+                <input
+                  type="password"
+                  autoComplete={mode === "register" ? "new-password" : "current-password"}
+                  value={draft.password}
+                  onChange={(event) =>
+                    onDraftChange({ ...draft, password: event.target.value })
+                  }
+                  placeholder={
+                    mode === "register" ? "At least 8 characters" : "Your password"
+                  }
+                  className="w-full rounded-[0.85rem] border border-[#DDD8D1] bg-white px-4 py-3 text-[0.9rem] text-[#1A1410] outline-none placeholder:text-[#C0B8AF] transition-[border-color,box-shadow] duration-200 focus:border-[#E07468] focus:shadow-[0_0_0_3px_rgba(224,116,104,0.15)]"
+                />
+              </label>
+
+              <p className="text-[0.79rem] text-[#A09890]">
+                {mode === "register"
+                  ? "Use email if you prefer a password instead."
+                  : "Use the same email you used when you saved your date."}
+              </p>
+
+              {errorMessage ? (
+                <p className="rounded-[0.85rem] border border-[#F0CECA] bg-[#FDF3F2] px-4 py-3 text-[0.87rem] text-[#C0504A]">
+                  {errorMessage}
+                </p>
+              ) : null}
+
+              <Button
+                onClick={onSubmit}
+                loading={submitting}
+                className="rounded-[0.85rem]"
+              >
+                {getAuthSheetSubmitLabel(mode)}
+              </Button>
+            </div>
+
+            {/* Fine print */}
+            <p className="mt-5 text-[0.7rem] leading-relaxed text-[#B0A89F]">
+              By continuing, you agree to save this date to your account. We only
+              use your details to sign you in and keep your plans accessible.
             </p>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="cursor-pointer rounded-full border border-muted bg-bg px-3 py-2 text-caption font-medium text-text-secondary transition-colors duration-200 hover:border-text-secondary hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-          >
-            Close
-          </button>
-        </div>
-
-        <div className="mt-5 grid grid-cols-2 gap-2 rounded-2xl bg-bg p-1.5">
-          <button
-            type="button"
-            onClick={() => onModeChange("register")}
-            className={`cursor-pointer rounded-[1rem] px-4 py-3 text-body font-semibold transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${
-              mode === "register"
-                ? "bg-white text-text shadow-sm"
-                : "text-text-secondary hover:text-text"
-            }`}
-          >
-            Create account
-          </button>
-          <button
-            type="button"
-            onClick={() => onModeChange("login")}
-            className={`cursor-pointer rounded-[1rem] px-4 py-3 text-body font-semibold transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${
-              mode === "login"
-                ? "bg-white text-text shadow-sm"
-                : "text-text-secondary hover:text-text"
-            }`}
-          >
-            Log in
-          </button>
-        </div>
-
-        <div className="mt-5 space-y-4">
-          <label className="block">
-            <span className="mb-2 block text-caption font-semibold uppercase tracking-[0.14em] text-text-secondary">
-              Email
-            </span>
-            <input
-              type="email"
-              autoComplete="email"
-              value={draft.email}
-              onChange={(event) =>
-                onDraftChange({
-                  ...draft,
-                  email: event.target.value,
-                })
-              }
-              className="w-full rounded-2xl border border-muted bg-white px-4 py-3 text-body text-text outline-none transition-colors duration-200 placeholder:text-text-secondary/70 focus:border-primary"
-              placeholder="you@example.com"
-            />
-          </label>
-
-          <label className="block">
-            <span className="mb-2 block text-caption font-semibold uppercase tracking-[0.14em] text-text-secondary">
-              Password
-            </span>
-            <input
-              type="password"
-              autoComplete={mode === "register" ? "new-password" : "current-password"}
-              value={draft.password}
-              onChange={(event) =>
-                onDraftChange({
-                  ...draft,
-                  password: event.target.value,
-                })
-              }
-              className="w-full rounded-2xl border border-muted bg-white px-4 py-3 text-body text-text outline-none transition-colors duration-200 placeholder:text-text-secondary/70 focus:border-primary"
-              placeholder={mode === "register" ? "At least 8 characters" : "Your password"}
-            />
-          </label>
-
-          {errorMessage ? (
-            <p className="rounded-2xl border border-error/20 bg-error/8 px-4 py-3 text-body text-error">
-              {errorMessage}
-            </p>
-          ) : null}
-
-          <Button onClick={onSubmit} loading={submitting}>
-            {mode === "register" ? "Create account" : "Log in"}
-          </Button>
-
-          <Button variant="secondary" onClick={onGoogle} disabled={submitting}>
-            Continue with Google
-          </Button>
         </div>
       </div>
-    </div>
+    </>
+  );
+}
+
+/* ── Sub-components ── */
+
+type OAuthButtonProps = {
+  readonly onClick: () => void;
+  readonly disabled: boolean;
+  readonly variant: "dark" | "light";
+  readonly icon: React.ReactNode;
+  readonly label: string;
+};
+
+function OAuthButton({ onClick, disabled, variant, icon, label }: OAuthButtonProps) {
+  const base =
+    "flex h-[3.1rem] w-full cursor-pointer items-center justify-center gap-2.5 rounded-[0.85rem] px-4 text-[0.87rem] font-semibold transition-[transform,box-shadow,opacity] duration-200 motion-safe:hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#E07468] disabled:cursor-not-allowed disabled:opacity-50";
+
+  const dark =
+    "bg-[#0D0B09] text-white shadow-[0_2px_8px_rgba(0,0,0,0.22)] hover:shadow-[0_6px_22px_rgba(0,0,0,0.32)]";
+
+  const light =
+    "border border-[#DDD8D1] bg-white text-[#1A1410] shadow-[0_1px_4px_rgba(0,0,0,0.06)] hover:border-[#C8C0B5] hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)]";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`${base} ${variant === "dark" ? dark : light}`}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      <path d="M5 5l10 10M15 5L5 15" />
+    </svg>
+  );
+}
+
+function HeartDotIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3 w-3" fill="none">
+      <path
+        d="M8 13.5S2 9.5 2 5.5a3 3 0 0 1 6-1.02A3 3 0 0 1 14 5.5c0 4-6 8-6 8z"
+        fill="rgba(224,116,104,0.7)"
+      />
+    </svg>
+  );
+}
+
+function AppleIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className="h-[18px] w-[18px]"
+      fill="currentColor"
+    >
+      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+    </svg>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-[18px] w-[18px]">
+      <path
+        d="M21.8 12.23c0-.68-.06-1.33-.17-1.95H12v3.7h5.5a4.7 4.7 0 0 1-2.04 3.09v2.57h3.3c1.93-1.78 3.04-4.41 3.04-7.41Z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 22c2.76 0 5.08-.91 6.77-2.47l-3.3-2.57c-.91.61-2.08.97-3.47.97-2.67 0-4.93-1.8-5.73-4.22H2.86v2.64A10 10 0 0 0 12 22Z"
+        fill="#34A853"
+      />
+      <path
+        d="M6.27 13.71A5.98 5.98 0 0 1 5.95 12c0-.59.11-1.17.32-1.71V7.65H2.86A10 10 0 0 0 2 12c0 1.6.38 3.12 1.06 4.35l3.21-2.64Z"
+        fill="#FBBC04"
+      />
+      <path
+        d="M12 6.07c1.5 0 2.85.52 3.91 1.53l2.93-2.93C17.07 2.99 14.76 2 12 2 8.09 2 4.71 4.24 3.06 7.65l3.21 2.64C7.07 7.87 9.33 6.07 12 6.07Z"
+        fill="#EA4335"
+      />
+    </svg>
   );
 }

--- a/web-service/src/components/button.tsx
+++ b/web-service/src/components/button.tsx
@@ -12,7 +12,7 @@ type ButtonProps = {
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children">;
 
 const baseStyles =
-  "flex w-full items-center justify-center gap-2 rounded-2xl text-body font-semibold transition-all duration-200 h-14 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary motion-safe:-translate-y-0.5";
+  "flex w-full items-center justify-center gap-2 rounded-2xl text-body font-semibold transition-all duration-200 h-14 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary";
 
 const variantStyles: Record<ButtonVariant, string> = {
   primary:

--- a/web-service/src/components/button.tsx
+++ b/web-service/src/components/button.tsx
@@ -12,20 +12,20 @@ type ButtonProps = {
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children">;
 
 const baseStyles =
-  "flex w-full items-center justify-center gap-2 rounded-2xl text-body font-semibold transition-all duration-200 h-14 cursor-pointer";
+  "flex w-full items-center justify-center gap-2 rounded-2xl text-body font-semibold transition-all duration-200 h-14 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary motion-safe:-translate-y-0.5";
 
 const variantStyles: Record<ButtonVariant, string> = {
   primary:
-    "bg-primary text-white shadow-sm hover:bg-primary-hover active:scale-[0.98]",
+    "bg-primary text-white shadow-sm hover:bg-primary-hover hover:shadow-[0_14px_26px_rgba(224,116,104,0.24)] motion-safe:hover:-translate-y-0.5",
   secondary:
-    "bg-surface text-text border-[1.5px] border-muted hover:border-text-secondary active:scale-[0.98]",
+    "bg-surface text-text border-[1.5px] border-muted hover:border-text-secondary hover:shadow-[0_12px_20px_rgba(45,42,38,0.08)] motion-safe:hover:-translate-y-0.5",
 };
 
 const disabledStyles =
-  "bg-muted text-text-secondary cursor-not-allowed shadow-none hover:bg-muted active:scale-100";
+  "bg-muted text-text-secondary cursor-not-allowed shadow-none hover:bg-muted";
 
 const loadingStyles =
-  "bg-primary/70 text-white/90 cursor-wait shadow-none hover:bg-primary/70 active:scale-100";
+  "bg-primary/70 text-white/90 cursor-wait shadow-none hover:bg-primary/70";
 
 /**
  * Shared button component with primary/secondary variants and

--- a/web-service/src/components/history-card.tsx
+++ b/web-service/src/components/history-card.tsx
@@ -1,0 +1,75 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { HistorySession } from "../lib/services/session-history-service";
+import { getHistoryRoleLabel } from "../app/history/history-page-state";
+
+type HistoryCardProps = {
+  readonly session: HistorySession;
+};
+
+export function HistoryCard({ session }: HistoryCardProps) {
+  const title = session.matchedVenue?.name ?? "Expired plan";
+  const body =
+    session.matchedVenue?.address ?? "No match was saved from this round.";
+
+  return (
+    <article className="overflow-hidden rounded-[1.75rem] border border-white/70 bg-white/90 shadow-[0_18px_40px_rgba(45,42,38,0.08)] transition-all duration-200 hover:shadow-[0_24px_48px_rgba(45,42,38,0.12)] motion-safe:hover:-translate-y-0.5">
+      <div className="grid gap-0 sm:grid-cols-[180px_1fr]">
+        <div className="relative min-h-[160px] bg-[linear-gradient(135deg,var(--color-secondary-muted),var(--color-primary-muted))]">
+          {session.matchedVenue?.photoUrl ? (
+            <Image
+              src={session.matchedVenue.photoUrl}
+              alt={session.matchedVenue.name}
+              fill
+              unoptimized
+              className="object-cover"
+              sizes="180px"
+            />
+          ) : (
+            <div className="flex h-full items-end p-4">
+              <span className="rounded-full border border-white/60 bg-white/20 px-3 py-1 text-caption font-medium text-white backdrop-blur">
+                No saved photo
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-4 p-5">
+          <div className="flex flex-wrap items-center gap-2 text-caption text-text-secondary">
+            <span className="rounded-full border border-muted bg-bg px-3 py-1.5">
+              {getHistoryRoleLabel(session.role)}
+            </span>
+            <span className="rounded-full border border-muted bg-bg px-3 py-1.5 capitalize">
+              {session.status}
+            </span>
+          </div>
+
+          <div>
+            <h2 className="text-h2 font-semibold text-text">{title}</h2>
+            <p className="mt-2 text-body text-text-secondary">{body}</p>
+          </div>
+
+          <div className="mt-auto flex items-center justify-between gap-3">
+            <p className="text-caption text-text-secondary">
+              {new Date(session.createdAt).toLocaleDateString("en-US", {
+                month: "long",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </p>
+            <Link
+              href={
+                session.status === "matched"
+                  ? `/plan/${session.sessionId}/results`
+                  : `/plan/${session.sessionId}`
+              }
+              className="cursor-pointer rounded-full border border-muted bg-bg px-4 py-2 text-caption font-semibold text-text transition-colors duration-200 hover:border-text-secondary hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
+              View result
+            </Link>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/web-service/src/lib/__tests__/accounts-migration.test.ts
+++ b/web-service/src/lib/__tests__/accounts-migration.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const currentFile = fileURLToPath(import.meta.url);
+const currentDir = dirname(currentFile);
+
+const migrationPath = join(
+  currentDir,
+  "..",
+  "..",
+  "..",
+  "supabase",
+  "migrations",
+  "011_create_accounts_and_session_accounts.sql",
+);
+
+function readMigration(): string {
+  return readFileSync(migrationPath, "utf8");
+}
+
+describe("011_create_accounts_and_session_accounts.sql", () => {
+  it("creates the accounts table keyed by Supabase auth user id", () => {
+    const migration = readMigration();
+
+    expect(migration).toContain("CREATE TABLE accounts");
+    expect(migration).toContain("id uuid PRIMARY KEY");
+    expect(migration).toContain("email text NOT NULL UNIQUE");
+    expect(migration).toContain("created_at timestamptz NOT NULL DEFAULT now()");
+  });
+
+  it("creates the session_accounts join table with role and cascades", () => {
+    const migration = readMigration();
+
+    expect(migration).toContain("CREATE TABLE session_accounts");
+    expect(migration).toContain(
+      "session_id uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE",
+    );
+    expect(migration).toContain(
+      "account_id uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE",
+    );
+    expect(migration).toContain("role text NOT NULL CHECK (role IN ('a', 'b'))");
+    expect(migration).toContain("PRIMARY KEY (session_id, account_id)");
+  });
+
+  it("indexes session history lookups by account", () => {
+    const migration = readMigration();
+
+    expect(migration).toContain("CREATE INDEX idx_session_accounts_account");
+    expect(migration).toContain("ON session_accounts (account_id)");
+  });
+});

--- a/web-service/src/lib/__tests__/accounts-security-migration.test.ts
+++ b/web-service/src/lib/__tests__/accounts-security-migration.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const currentFile = fileURLToPath(import.meta.url);
+const currentDir = dirname(currentFile);
+
+const migrationPath = join(
+  currentDir,
+  "..",
+  "..",
+  "..",
+  "supabase",
+  "migrations",
+  "012_secure_accounts_and_session_accounts.sql",
+);
+
+function readMigration(): string {
+  return readFileSync(migrationPath, "utf8");
+}
+
+describe("012_secure_accounts_and_session_accounts.sql", () => {
+  it("enables RLS on account history tables", () => {
+    const migration = readMigration();
+
+    expect(migration).toContain("ALTER TABLE accounts ENABLE ROW LEVEL SECURITY");
+    expect(migration).toContain(
+      "ALTER TABLE session_accounts ENABLE ROW LEVEL SECURITY",
+    );
+  });
+
+  it("prevents multiple accounts from claiming the same session role", () => {
+    const migration = readMigration();
+
+    expect(migration).toContain(
+      "ADD CONSTRAINT session_accounts_session_id_role_key",
+    );
+    expect(migration).toContain("UNIQUE (session_id, role)");
+  });
+});

--- a/web-service/src/lib/__tests__/auth-client.test.ts
+++ b/web-service/src/lib/__tests__/auth-client.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchCurrentAccount } from "../auth-client";
+
+const mockFetch = vi.fn();
+
+describe("auth-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("fetches the current account with the bearer token", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        account: {
+          id: "account-1",
+          email: "alex@example.com",
+          createdAt: "2026-04-13T20:00:00.000Z",
+        },
+      }),
+    });
+
+    const result = await fetchCurrentAccount("token-123");
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/auth/me", {
+      headers: {
+        Authorization: "Bearer token-123",
+      },
+    });
+    expect(result).toEqual({
+      id: "account-1",
+      email: "alex@example.com",
+      createdAt: "2026-04-13T20:00:00.000Z",
+    });
+  });
+
+  it("surfaces auth route errors as exceptions", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        error: "Invalid token",
+      }),
+    });
+
+    await expect(fetchCurrentAccount("bad-token")).rejects.toThrow(
+      "Invalid token",
+    );
+  });
+});

--- a/web-service/src/lib/__tests__/auth-token-storage.test.ts
+++ b/web-service/src/lib/__tests__/auth-token-storage.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clearStoredAccountSummary,
+  clearStoredAuthToken,
+  getStoredAccountSummary,
+  getStoredAuthToken,
+  setStoredAccountSummary,
+  setStoredAuthToken,
+} from "../auth-token-storage";
+
+describe("auth-token-storage", () => {
+  it("stores the auth token for later history requests", () => {
+    const storage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+
+    setStoredAuthToken(storage, "token-123");
+
+    expect(storage.setItem).toHaveBeenCalledWith("dateflow:auth-token", "token-123");
+  });
+
+  it("reads the auth token back from storage", () => {
+    const storage = {
+      getItem: vi.fn(() => "token-123"),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+
+    expect(getStoredAuthToken(storage)).toBe("token-123");
+  });
+
+  it("clears the stored auth token", () => {
+    const storage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+
+    clearStoredAuthToken(storage);
+
+    expect(storage.removeItem).toHaveBeenCalledWith("dateflow:auth-token");
+  });
+
+  it("stores and reads the signed-in account summary", () => {
+    const storage = {
+      getItem: vi.fn(() =>
+        JSON.stringify({
+          email: "alex@example.com",
+        }),
+      ),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+
+    setStoredAccountSummary(storage, {
+      email: "alex@example.com",
+    });
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      "dateflow:account-summary",
+      JSON.stringify({ email: "alex@example.com" }),
+    );
+    expect(getStoredAccountSummary(storage)).toEqual({
+      email: "alex@example.com",
+    });
+  });
+
+  it("clears the stored account summary", () => {
+    const storage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+
+    clearStoredAccountSummary(storage);
+
+    expect(storage.removeItem).toHaveBeenCalledWith("dateflow:account-summary");
+  });
+});

--- a/web-service/src/lib/__tests__/history-client.test.ts
+++ b/web-service/src/lib/__tests__/history-client.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchHistory } from "../history-client";
+
+const mockFetch = vi.fn();
+
+describe("history-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("fetches the default matched-history view with the bearer token", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sessions: [],
+        page: 1,
+        pageSize: 10,
+        totalCount: 0,
+        totalPages: 0,
+      }),
+    });
+
+    const result = await fetchHistory("token-123");
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/sessions/history?page=1&pageSize=10", {
+      headers: {
+        Authorization: "Bearer token-123",
+      },
+    });
+    expect(result.totalCount).toBe(0);
+  });
+
+  it("adds includeAll when requesting the broader history filter", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sessions: [],
+        page: 1,
+        pageSize: 10,
+        totalCount: 0,
+        totalPages: 0,
+      }),
+    });
+
+    await fetchHistory("token-123", { includeAll: true, page: 2, pageSize: 5 });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/sessions/history?page=2&pageSize=5&includeAll=true",
+      {
+        headers: {
+          Authorization: "Bearer token-123",
+        },
+      },
+    );
+  });
+});

--- a/web-service/src/lib/__tests__/session-link-storage.test.ts
+++ b/web-service/src/lib/__tests__/session-link-storage.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DATEFLOW_SESSION_LINK_KEY,
+  clearStoredSessionLink,
+  loadStoredSessionLink,
+  persistSessionLink,
+} from "../session-link-storage";
+
+describe("session-link-storage", () => {
+  it("writes the latest session link payload into localStorage", () => {
+    const storage = {
+      setItem: vi.fn(),
+      getItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+
+    persistSessionLink(storage, {
+      sessionId: "session-1",
+      role: "b",
+    });
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      DATEFLOW_SESSION_LINK_KEY,
+      JSON.stringify({
+        sessionId: "session-1",
+        role: "b",
+      }),
+    );
+  });
+
+  it("reads a valid stored payload back out of localStorage", () => {
+    const storage = {
+      setItem: vi.fn(),
+      getItem: vi.fn(() =>
+        JSON.stringify({
+          sessionId: "session-1",
+          role: "a",
+        }),
+      ),
+      removeItem: vi.fn(),
+    };
+
+    expect(loadStoredSessionLink(storage)).toEqual({
+      sessionId: "session-1",
+      role: "a",
+    });
+  });
+
+  it("drops malformed stored data instead of throwing", () => {
+    const storage = {
+      setItem: vi.fn(),
+      getItem: vi.fn(() => "{bad json"),
+      removeItem: vi.fn(),
+    };
+
+    expect(loadStoredSessionLink(storage)).toBeNull();
+    expect(storage.removeItem).toHaveBeenCalledWith(DATEFLOW_SESSION_LINK_KEY);
+  });
+
+  it("clears the stored session link explicitly after a successful account save", () => {
+    const storage = {
+      setItem: vi.fn(),
+      getItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+
+    clearStoredSessionLink(storage);
+
+    expect(storage.removeItem).toHaveBeenCalledWith(DATEFLOW_SESSION_LINK_KEY);
+  });
+});

--- a/web-service/src/lib/auth-client.ts
+++ b/web-service/src/lib/auth-client.ts
@@ -1,0 +1,62 @@
+export async function submitAuthRequest(
+  endpoint: "/api/auth/register" | "/api/auth/login",
+  body: Record<string, string>,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const payload = (await response.json()) as Record<string, unknown>;
+
+  if (!response.ok) {
+    throw new Error(
+      typeof payload.error === "string"
+        ? payload.error
+        : "Something went wrong. Please try again.",
+    );
+  }
+
+  return payload;
+}
+
+export async function beginGoogleLogin(redirectTo: string): Promise<string> {
+  const payload = await submitAuthRequest("/api/auth/login", {
+    provider: "google",
+    redirectTo,
+  });
+
+  if (typeof payload.url !== "string") {
+    throw new Error("Google sign-in did not return a redirect URL");
+  }
+
+  return payload.url;
+}
+
+export async function fetchCurrentAccount(
+  token: string,
+): Promise<Record<string, unknown>> {
+  const response = await fetch("/api/auth/me", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const payload = (await response.json()) as {
+    account?: Record<string, unknown>;
+    error?: string;
+  };
+
+  if (!response.ok) {
+    throw new Error(payload.error ?? "Failed to load account");
+  }
+
+  if (!payload.account) {
+    throw new Error("Failed to load account");
+  }
+
+  return payload.account;
+}

--- a/web-service/src/lib/auth-client.ts
+++ b/web-service/src/lib/auth-client.ts
@@ -36,6 +36,19 @@ export async function beginGoogleLogin(redirectTo: string): Promise<string> {
   return payload.url;
 }
 
+export async function beginAppleLogin(redirectTo: string): Promise<string> {
+  const payload = await submitAuthRequest("/api/auth/login", {
+    provider: "apple",
+    redirectTo,
+  });
+
+  if (typeof payload.url !== "string") {
+    throw new Error("Apple sign-in did not return a redirect URL");
+  }
+
+  return payload.url;
+}
+
 export async function fetchCurrentAccount(
   token: string,
 ): Promise<Record<string, unknown>> {

--- a/web-service/src/lib/auth-token-storage.ts
+++ b/web-service/src/lib/auth-token-storage.ts
@@ -1,0 +1,59 @@
+export const DATEFLOW_AUTH_TOKEN_KEY = "dateflow:auth-token";
+export const DATEFLOW_ACCOUNT_SUMMARY_KEY = "dateflow:account-summary";
+
+export type StoredAccountSummary = {
+  readonly email: string;
+};
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export function setStoredAuthToken(storage: StorageLike, token: string): void {
+  storage.setItem(DATEFLOW_AUTH_TOKEN_KEY, token);
+}
+
+export function getStoredAuthToken(storage: StorageLike): string | null {
+  return storage.getItem(DATEFLOW_AUTH_TOKEN_KEY);
+}
+
+export function clearStoredAuthToken(storage: StorageLike): void {
+  storage.removeItem(DATEFLOW_AUTH_TOKEN_KEY);
+}
+
+export function setStoredAccountSummary(
+  storage: StorageLike,
+  summary: StoredAccountSummary,
+): void {
+  storage.setItem(DATEFLOW_ACCOUNT_SUMMARY_KEY, JSON.stringify(summary));
+}
+
+export function getStoredAccountSummary(
+  storage: StorageLike,
+): StoredAccountSummary | null {
+  const raw = storage.getItem(DATEFLOW_ACCOUNT_SUMMARY_KEY);
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.email === "string"
+    ) {
+      return { email: parsed.email };
+    }
+  } catch {
+    storage.removeItem(DATEFLOW_ACCOUNT_SUMMARY_KEY);
+    return null;
+  }
+
+  storage.removeItem(DATEFLOW_ACCOUNT_SUMMARY_KEY);
+  return null;
+}
+
+export function clearStoredAccountSummary(storage: StorageLike): void {
+  storage.removeItem(DATEFLOW_ACCOUNT_SUMMARY_KEY);
+}

--- a/web-service/src/lib/history-client.ts
+++ b/web-service/src/lib/history-client.ts
@@ -1,0 +1,39 @@
+import type { SessionHistoryPage } from "./services/session-history-service";
+
+type FetchHistoryOptions = {
+  readonly includeAll?: boolean;
+  readonly page?: number;
+  readonly pageSize?: number;
+};
+
+export async function fetchHistory(
+  token: string,
+  options: FetchHistoryOptions = {},
+): Promise<SessionHistoryPage> {
+  const page = options.page ?? 1;
+  const pageSize = options.pageSize ?? 10;
+  const query = new URLSearchParams({
+    page: String(page),
+    pageSize: String(pageSize),
+  });
+
+  if (options.includeAll) {
+    query.set("includeAll", "true");
+  }
+
+  const response = await fetch(`/api/sessions/history?${query.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const payload = (await response.json()) as SessionHistoryPage & {
+    error?: string;
+  };
+
+  if (!response.ok) {
+    throw new Error(payload.error ?? "Failed to load history");
+  }
+
+  return payload;
+}

--- a/web-service/src/lib/services/__tests__/account-service.test.ts
+++ b/web-service/src/lib/services/__tests__/account-service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  beginAppleOAuth,
   beginGoogleOAuth,
   getAccountByAccessToken,
   login,
@@ -91,6 +92,56 @@ describe("account-service register", () => {
       "Email already registered",
     );
   });
+
+  it("falls back to password sign-in when sign-up returns a user without a session", async () => {
+    mockAuthSignUp.mockResolvedValue({
+      data: {
+        user: { id: "account-1", email: "alex@example.com" },
+        session: null,
+      },
+      error: null,
+    });
+    mockAuthSignInWithPassword.mockResolvedValue({
+      data: {
+        user: { id: "account-1", email: "alex@example.com" },
+        session: { access_token: "token-789" },
+      },
+      error: null,
+    });
+
+    const result = await register("alex@example.com", "supersecret");
+
+    expect(mockAuthSignInWithPassword).toHaveBeenCalledWith({
+      email: "alex@example.com",
+      password: "supersecret",
+    });
+    expect(result).toEqual({
+      token: "token-789",
+      account: {
+        id: "account-1",
+        email: "alex@example.com",
+        createdAt: new Date("2026-04-13T20:00:00.000Z"),
+      },
+    });
+  });
+
+  it("surfaces a confirmation-required message when sign-up creates a user without a session and fallback sign-in is blocked", async () => {
+    mockAuthSignUp.mockResolvedValue({
+      data: {
+        user: { id: "account-1", email: "alex@example.com" },
+        session: null,
+      },
+      error: null,
+    });
+    mockAuthSignInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Email not confirmed" },
+    });
+
+    await expect(register("alex@example.com", "supersecret")).rejects.toThrow(
+      "Check your email to confirm your account",
+    );
+  });
 });
 
 describe("account-service login", () => {
@@ -163,6 +214,28 @@ describe("account-service beginGoogleOAuth", () => {
       },
     });
     expect(url).toBe("https://supabase.test/auth/v1/authorize?provider=google");
+  });
+});
+
+describe("account-service beginAppleOAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthSignInWithOAuth.mockResolvedValue({
+      data: { url: "https://supabase.test/auth/v1/authorize?provider=apple" },
+      error: null,
+    });
+  });
+
+  it("starts the Apple OAuth flow and returns the redirect url", async () => {
+    const url = await beginAppleOAuth("http://localhost:3000/history");
+
+    expect(mockAuthSignInWithOAuth).toHaveBeenCalledWith({
+      provider: "apple",
+      options: {
+        redirectTo: "http://localhost:3000/history",
+      },
+    });
+    expect(url).toBe("https://supabase.test/auth/v1/authorize?provider=apple");
   });
 });
 

--- a/web-service/src/lib/services/__tests__/account-service.test.ts
+++ b/web-service/src/lib/services/__tests__/account-service.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beginGoogleOAuth,
+  getAccountByAccessToken,
+  login,
+  register,
+} from "../account-service";
+
+const mockAuthSignUp = vi.fn();
+const mockAuthSignInWithPassword = vi.fn();
+const mockAuthSignInWithOAuth = vi.fn();
+const mockAuthGetUser = vi.fn();
+const mockAnonFromSingle = vi.fn();
+const mockAnonFromEq = vi.fn(() => ({ single: mockAnonFromSingle }));
+const mockAnonFromSelect = vi.fn(() => ({ eq: mockAnonFromEq }));
+const mockAnonFrom = vi.fn(() => ({ select: mockAnonFromSelect }));
+
+const mockServerInsertSingle = vi.fn();
+const mockServerInsertSelect = vi.fn(() => ({ single: mockServerInsertSingle }));
+const mockServerInsert = vi.fn(() => ({ select: mockServerInsertSelect }));
+const mockServerFrom = vi.fn(() => ({ insert: mockServerInsert }));
+
+vi.mock("../../supabase", () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      signUp: (...args: unknown[]) => mockAuthSignUp(...args),
+      signInWithPassword: (...args: unknown[]) =>
+        mockAuthSignInWithPassword(...args),
+      signInWithOAuth: (...args: unknown[]) => mockAuthSignInWithOAuth(...args),
+      getUser: (...args: unknown[]) => mockAuthGetUser(...args),
+    },
+    from: (...args: unknown[]) => mockAnonFrom(...args),
+  }),
+}));
+
+vi.mock("../../supabase-server", () => ({
+  getSupabaseServerClient: () => ({
+    from: (...args: unknown[]) => mockServerFrom(...args),
+  }),
+}));
+
+describe("account-service register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthSignUp.mockResolvedValue({
+      data: {
+        user: { id: "account-1", email: "alex@example.com" },
+        session: { access_token: "token-123" },
+      },
+      error: null,
+    });
+    mockServerInsertSingle.mockResolvedValue({
+      data: {
+        id: "account-1",
+        email: "alex@example.com",
+        created_at: "2026-04-13T20:00:00Z",
+      },
+      error: null,
+    });
+  });
+
+  it("creates a Supabase auth user, persists the account row, and returns token plus account", async () => {
+    const result = await register("alex@example.com", "supersecret");
+
+    expect(mockAuthSignUp).toHaveBeenCalledWith({
+      email: "alex@example.com",
+      password: "supersecret",
+    });
+    expect(mockServerFrom).toHaveBeenCalledWith("accounts");
+    expect(mockServerInsert).toHaveBeenCalledWith({
+      id: "account-1",
+      email: "alex@example.com",
+    });
+    expect(result).toEqual({
+      token: "token-123",
+      account: {
+        id: "account-1",
+        email: "alex@example.com",
+        createdAt: new Date("2026-04-13T20:00:00.000Z"),
+      },
+    });
+  });
+
+  it("surfaces duplicate email as a conflict-friendly error", async () => {
+    mockAuthSignUp.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "User already registered" },
+    });
+
+    await expect(register("alex@example.com", "supersecret")).rejects.toThrow(
+      "Email already registered",
+    );
+  });
+});
+
+describe("account-service login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthSignInWithPassword.mockResolvedValue({
+      data: {
+        user: { id: "account-1", email: "alex@example.com" },
+        session: { access_token: "token-456" },
+      },
+      error: null,
+    });
+    mockAnonFromSingle.mockResolvedValue({
+      data: {
+        id: "account-1",
+        email: "alex@example.com",
+        created_at: "2026-04-13T20:00:00Z",
+      },
+      error: null,
+    });
+  });
+
+  it("authenticates and returns the linked account plus token", async () => {
+    const result = await login("alex@example.com", "supersecret");
+
+    expect(mockAuthSignInWithPassword).toHaveBeenCalledWith({
+      email: "alex@example.com",
+      password: "supersecret",
+    });
+    expect(mockAnonFrom).toHaveBeenCalledWith("accounts");
+    expect(mockAnonFromEq).toHaveBeenCalledWith("id", "account-1");
+    expect(result).toEqual({
+      token: "token-456",
+      account: {
+        id: "account-1",
+        email: "alex@example.com",
+        createdAt: new Date("2026-04-13T20:00:00.000Z"),
+      },
+    });
+  });
+
+  it("maps invalid credentials into a stable auth error", async () => {
+    mockAuthSignInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Invalid login credentials" },
+    });
+
+    await expect(login("alex@example.com", "wrongpass")).rejects.toThrow(
+      "Invalid credentials",
+    );
+  });
+});
+
+describe("account-service beginGoogleOAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthSignInWithOAuth.mockResolvedValue({
+      data: { url: "https://supabase.test/auth/v1/authorize?provider=google" },
+      error: null,
+    });
+  });
+
+  it("starts the Google OAuth flow and returns the redirect url", async () => {
+    const url = await beginGoogleOAuth("http://localhost:3000/history");
+
+    expect(mockAuthSignInWithOAuth).toHaveBeenCalledWith({
+      provider: "google",
+      options: {
+        redirectTo: "http://localhost:3000/history",
+      },
+    });
+    expect(url).toBe("https://supabase.test/auth/v1/authorize?provider=google");
+  });
+});
+
+describe("account-service getAccountByAccessToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthGetUser.mockResolvedValue({
+      data: { user: { id: "account-1" } },
+      error: null,
+    });
+    mockAnonFromSingle.mockResolvedValue({
+      data: {
+        id: "account-1",
+        email: "alex@example.com",
+        created_at: "2026-04-13T20:00:00Z",
+      },
+      error: null,
+    });
+  });
+
+  it("hydrates the account row from a valid access token", async () => {
+    const account = await getAccountByAccessToken("token-789");
+
+    expect(mockAuthGetUser).toHaveBeenCalledWith("token-789");
+    expect(mockAnonFrom).toHaveBeenCalledWith("accounts");
+    expect(mockAnonFromEq).toHaveBeenCalledWith("id", "account-1");
+    expect(account).toEqual({
+      id: "account-1",
+      email: "alex@example.com",
+      createdAt: new Date("2026-04-13T20:00:00.000Z"),
+    });
+  });
+
+  it("returns an invalid-token error when Supabase rejects the access token", async () => {
+    mockAuthGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: "invalid jwt" },
+    });
+
+    await expect(getAccountByAccessToken("bad-token")).rejects.toThrow(
+      "Invalid token",
+    );
+  });
+});

--- a/web-service/src/lib/services/__tests__/account-service.test.ts
+++ b/web-service/src/lib/services/__tests__/account-service.test.ts
@@ -19,7 +19,13 @@ const mockAnonFrom = vi.fn(() => ({ select: mockAnonFromSelect }));
 const mockServerInsertSingle = vi.fn();
 const mockServerInsertSelect = vi.fn(() => ({ single: mockServerInsertSingle }));
 const mockServerInsert = vi.fn(() => ({ select: mockServerInsertSelect }));
-const mockServerFrom = vi.fn(() => ({ insert: mockServerInsert }));
+const mockServerSelectSingle = vi.fn();
+const mockServerSelectEq = vi.fn(() => ({ single: mockServerSelectSingle }));
+const mockServerSelect = vi.fn(() => ({ eq: mockServerSelectEq }));
+const mockServerFrom = vi.fn(() => ({
+  insert: mockServerInsert,
+  select: mockServerSelect,
+}));
 
 vi.mock("../../supabase", () => ({
   getSupabaseClient: () => ({
@@ -154,7 +160,7 @@ describe("account-service login", () => {
       },
       error: null,
     });
-    mockAnonFromSingle.mockResolvedValue({
+    mockServerSelectSingle.mockResolvedValue({
       data: {
         id: "account-1",
         email: "alex@example.com",
@@ -171,8 +177,7 @@ describe("account-service login", () => {
       email: "alex@example.com",
       password: "supersecret",
     });
-    expect(mockAnonFrom).toHaveBeenCalledWith("accounts");
-    expect(mockAnonFromEq).toHaveBeenCalledWith("id", "account-1");
+    expect(mockServerFrom).toHaveBeenCalledWith("accounts");
     expect(result).toEqual({
       token: "token-456",
       account: {
@@ -246,7 +251,7 @@ describe("account-service getAccountByAccessToken", () => {
       data: { user: { id: "account-1" } },
       error: null,
     });
-    mockAnonFromSingle.mockResolvedValue({
+    mockServerSelectSingle.mockResolvedValue({
       data: {
         id: "account-1",
         email: "alex@example.com",
@@ -260,8 +265,7 @@ describe("account-service getAccountByAccessToken", () => {
     const account = await getAccountByAccessToken("token-789");
 
     expect(mockAuthGetUser).toHaveBeenCalledWith("token-789");
-    expect(mockAnonFrom).toHaveBeenCalledWith("accounts");
-    expect(mockAnonFromEq).toHaveBeenCalledWith("id", "account-1");
+    expect(mockServerFrom).toHaveBeenCalledWith("accounts");
     expect(account).toEqual({
       id: "account-1",
       email: "alex@example.com",

--- a/web-service/src/lib/services/__tests__/session-history-query-service.test.ts
+++ b/web-service/src/lib/services/__tests__/session-history-query-service.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getHistory } from "../session-history-service";
+
+const mockSessionAccountsEq = vi.fn();
+const mockSessionAccountsSelect = vi.fn(() => ({ eq: mockSessionAccountsEq }));
+
+const mockSessionsOrder = vi.fn();
+const mockSessionsIn = vi.fn(() => ({ order: mockSessionsOrder }));
+const mockSessionsSelect = vi.fn(() => ({ in: mockSessionsIn }));
+
+const mockVenuesIn = vi.fn();
+const mockVenuesSelect = vi.fn(() => ({ in: mockVenuesIn }));
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "session_accounts") {
+    return { select: mockSessionAccountsSelect };
+  }
+
+  if (table === "sessions") {
+    return { select: mockSessionsSelect };
+  }
+
+  if (table === "venues") {
+    return { select: mockVenuesSelect };
+  }
+
+  throw new Error(`Unexpected table ${table}`);
+});
+
+vi.mock("../../supabase-server", () => ({
+  getSupabaseServerClient: () => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  }),
+}));
+
+describe("session-history-service getHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSessionAccountsEq.mockResolvedValue({
+      data: [
+        { session_id: "session-1", account_id: "account-1", role: "a", linked_at: "2026-04-13T20:00:00Z" },
+        { session_id: "session-2", account_id: "account-1", role: "b", linked_at: "2026-04-12T20:00:00Z" },
+      ],
+      error: null,
+    });
+    mockSessionsOrder.mockResolvedValue({
+      data: [
+        {
+          id: "session-1",
+          status: "matched",
+          creator_display_name: "Alex",
+          invitee_display_name: "Jordan",
+          created_at: "2026-04-13T19:00:00Z",
+          expires_at: "2026-04-15T19:00:00Z",
+          matched_venue_id: "venue-1",
+          matched_at: "2026-04-13T20:00:00Z",
+        },
+        {
+          id: "session-2",
+          status: "expired",
+          creator_display_name: "Sam",
+          invitee_display_name: "Taylor",
+          created_at: "2026-04-12T18:00:00Z",
+          expires_at: "2026-04-14T18:00:00Z",
+          matched_venue_id: null,
+          matched_at: null,
+        },
+      ],
+      error: null,
+    });
+    mockVenuesIn.mockResolvedValue({
+      data: [
+        {
+          id: "venue-1",
+          session_id: "session-1",
+          place_id: "place-1",
+          name: "Cafe Blue",
+          category: "RESTAURANT",
+          address: "12 Main St, Austin, TX",
+          lat: 30.26,
+          lng: -97.74,
+          price_level: 2,
+          rating: 4.6,
+          photo_url: "https://example.com/photo.jpg",
+          photo_urls: ["https://example.com/photo.jpg"],
+          tags: ["cozy"],
+          round: 1,
+          position: 1,
+          score_category_overlap: 0.9,
+          score_distance_to_midpoint: 0.8,
+          score_first_date_suitability: 0.95,
+          score_quality_signal: 0.85,
+          score_time_of_day_fit: 0.75,
+        },
+      ],
+      error: null,
+    });
+  });
+
+  it("returns matched sessions by default, hydrated with venue cards", async () => {
+    const result = await getHistory("account-1", 1, 10);
+
+    expect(mockFrom).toHaveBeenCalledWith("session_accounts");
+    expect(mockSessionAccountsEq).toHaveBeenCalledWith("account_id", "account-1");
+    expect(mockFrom).toHaveBeenCalledWith("sessions");
+    expect(mockSessionsIn).toHaveBeenCalledWith("id", ["session-1", "session-2"]);
+    expect(result).toEqual({
+      sessions: [
+        {
+          sessionId: "session-1",
+          status: "matched",
+          createdAt: "2026-04-13T19:00:00.000Z",
+          role: "a",
+          matchedVenue: {
+            name: "Cafe Blue",
+            category: "RESTAURANT",
+            address: "12 Main St, Austin, TX",
+            photoUrl: "https://example.com/photo.jpg",
+          },
+        },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalCount: 1,
+      totalPages: 1,
+    });
+  });
+
+  it("supports includeAll to keep non-matched sessions in history", async () => {
+    const result = await getHistory("account-1", 1, 10, true);
+
+    expect(result.sessions).toHaveLength(2);
+    expect(result.sessions[1]).toEqual({
+      sessionId: "session-2",
+      status: "expired",
+      createdAt: "2026-04-12T18:00:00.000Z",
+      role: "b",
+      matchedVenue: null,
+    });
+  });
+
+  it("paginates after filtering", async () => {
+    mockSessionAccountsEq.mockResolvedValue({
+      data: [
+        { session_id: "session-1", account_id: "account-1", role: "a", linked_at: "2026-04-13T20:00:00Z" },
+        { session_id: "session-2", account_id: "account-1", role: "b", linked_at: "2026-04-12T20:00:00Z" },
+      ],
+      error: null,
+    });
+    mockSessionsOrder.mockResolvedValue({
+      data: [
+        {
+          id: "session-1",
+          status: "matched",
+          creator_display_name: "Alex",
+          invitee_display_name: "Jordan",
+          created_at: "2026-04-13T19:00:00Z",
+          expires_at: "2026-04-15T19:00:00Z",
+          matched_venue_id: "venue-1",
+          matched_at: "2026-04-13T20:00:00Z",
+        },
+        {
+          id: "session-2",
+          status: "matched",
+          creator_display_name: "Sam",
+          invitee_display_name: "Taylor",
+          created_at: "2026-04-12T18:00:00Z",
+          expires_at: "2026-04-14T18:00:00Z",
+          matched_venue_id: null,
+          matched_at: "2026-04-12T20:00:00Z",
+        },
+      ],
+      error: null,
+    });
+
+    const result = await getHistory("account-1", 2, 1);
+
+    expect(result.page).toBe(2);
+    expect(result.pageSize).toBe(1);
+    expect(result.totalCount).toBe(2);
+    expect(result.totalPages).toBe(2);
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].sessionId).toBe("session-2");
+  });
+});

--- a/web-service/src/lib/services/__tests__/session-history-query-service.test.ts
+++ b/web-service/src/lib/services/__tests__/session-history-query-service.test.ts
@@ -1,17 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getHistory } from "../session-history-service";
 
+const mockSessionAccountsRange = vi.fn();
+const mockSessionAccountsOrder = vi.fn(() => ({ range: mockSessionAccountsRange }));
 const mockSessionAccountsEq = vi.fn();
 const mockSessionAccountsSelect = vi.fn(() => ({ eq: mockSessionAccountsEq }));
-
-const mockSessionsRange = vi.fn();
-const mockSessionsOrder = vi.fn(() => ({ range: mockSessionsRange }));
-const mockSessionsEq = vi.fn(() => ({ order: mockSessionsOrder }));
-const mockSessionsIn = vi.fn(() => ({
-  eq: mockSessionsEq,
-  order: mockSessionsOrder,
-}));
-const mockSessionsSelect = vi.fn(() => ({ in: mockSessionsIn }));
+const mockSessionAccountsSessionsEq = vi.fn(() => ({ order: mockSessionAccountsOrder }));
 
 const mockVenuesIn = vi.fn();
 const mockVenuesSelect = vi.fn(() => ({ in: mockVenuesIn }));
@@ -19,10 +13,6 @@ const mockVenuesSelect = vi.fn(() => ({ in: mockVenuesIn }));
 const mockFrom = vi.fn((table: string) => {
   if (table === "session_accounts") {
     return { select: mockSessionAccountsSelect };
-  }
-
-  if (table === "sessions") {
-    return { select: mockSessionsSelect };
   }
 
   if (table === "venues") {
@@ -41,24 +31,28 @@ vi.mock("../../supabase-server", () => ({
 describe("session-history-service getHistory", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSessionAccountsEq.mockResolvedValue({
-      data: [
-        { session_id: "session-1", role: "a" },
-        { session_id: "session-2", role: "b" },
-      ],
-      error: null,
+    mockSessionAccountsEq.mockReturnValue({
+      eq: mockSessionAccountsSessionsEq,
+      order: mockSessionAccountsOrder,
     });
-    mockSessionsRange.mockResolvedValue({
+    mockSessionAccountsSessionsEq.mockReturnValue({
+      order: mockSessionAccountsOrder,
+    });
+    mockSessionAccountsRange.mockResolvedValue({
       data: [
         {
-          id: "session-1",
-          status: "matched",
-          creator_display_name: "Alex",
-          invitee_display_name: "Jordan",
-          created_at: "2026-04-13T19:00:00Z",
-          expires_at: "2026-04-15T19:00:00Z",
-          matched_venue_id: "venue-1",
-          matched_at: "2026-04-13T20:00:00Z",
+          session_id: "session-1",
+          role: "a",
+          sessions: {
+            id: "session-1",
+            status: "matched",
+            creator_display_name: "Alex",
+            invitee_display_name: "Jordan",
+            created_at: "2026-04-13T19:00:00Z",
+            expires_at: "2026-04-15T19:00:00Z",
+            matched_venue_id: "venue-1",
+            matched_at: "2026-04-13T20:00:00Z",
+          },
         },
       ],
       count: 1,
@@ -98,10 +92,15 @@ describe("session-history-service getHistory", () => {
 
     expect(mockFrom).toHaveBeenCalledWith("session_accounts");
     expect(mockSessionAccountsEq).toHaveBeenCalledWith("account_id", "account-1");
-    expect(mockFrom).toHaveBeenCalledWith("sessions");
-    expect(mockSessionsIn).toHaveBeenCalledWith("id", ["session-1", "session-2"]);
-    expect(mockSessionsEq).toHaveBeenCalledWith("status", "matched");
-    expect(mockSessionsRange).toHaveBeenCalledWith(0, 9);
+    expect(mockSessionAccountsSessionsEq).toHaveBeenCalledWith(
+      "sessions.status",
+      "matched",
+    );
+    expect(mockSessionAccountsOrder).toHaveBeenCalledWith("created_at", {
+      ascending: false,
+      referencedTable: "sessions",
+    });
+    expect(mockSessionAccountsRange).toHaveBeenCalledWith(0, 9);
     expect(result).toEqual({
       sessions: [
         {
@@ -125,27 +124,35 @@ describe("session-history-service getHistory", () => {
   });
 
   it("supports includeAll to keep non-matched sessions in history", async () => {
-    mockSessionsRange.mockResolvedValue({
+    mockSessionAccountsRange.mockResolvedValue({
       data: [
         {
-          id: "session-1",
-          status: "matched",
-          creator_display_name: "Alex",
-          invitee_display_name: "Jordan",
-          created_at: "2026-04-13T19:00:00Z",
-          expires_at: "2026-04-15T19:00:00Z",
-          matched_venue_id: "venue-1",
-          matched_at: "2026-04-13T20:00:00Z",
+          session_id: "session-1",
+          role: "a",
+          sessions: {
+            id: "session-1",
+            status: "matched",
+            creator_display_name: "Alex",
+            invitee_display_name: "Jordan",
+            created_at: "2026-04-13T19:00:00Z",
+            expires_at: "2026-04-15T19:00:00Z",
+            matched_venue_id: "venue-1",
+            matched_at: "2026-04-13T20:00:00Z",
+          },
         },
         {
-          id: "session-2",
-          status: "expired",
-          creator_display_name: "Sam",
-          invitee_display_name: "Taylor",
-          created_at: "2026-04-12T18:00:00Z",
-          expires_at: "2026-04-14T18:00:00Z",
-          matched_venue_id: null,
-          matched_at: null,
+          session_id: "session-2",
+          role: "b",
+          sessions: {
+            id: "session-2",
+            status: "expired",
+            creator_display_name: "Sam",
+            invitee_display_name: "Taylor",
+            created_at: "2026-04-12T18:00:00Z",
+            expires_at: "2026-04-14T18:00:00Z",
+            matched_venue_id: null,
+            matched_at: null,
+          },
         },
       ],
       count: 2,
@@ -154,7 +161,7 @@ describe("session-history-service getHistory", () => {
 
     const result = await getHistory("account-1", 1, 10, true);
 
-    expect(mockSessionsEq).not.toHaveBeenCalled();
+    expect(mockSessionAccountsSessionsEq).not.toHaveBeenCalled();
     expect(result.sessions).toHaveLength(2);
     expect(result.sessions[1]).toEqual({
       sessionId: "session-2",
@@ -165,25 +172,22 @@ describe("session-history-service getHistory", () => {
     });
   });
 
-  it("paginates in the sessions query", async () => {
-    mockSessionAccountsEq.mockResolvedValue({
-      data: [
-        { session_id: "session-1", role: "a" },
-        { session_id: "session-2", role: "b" },
-      ],
-      error: null,
-    });
-    mockSessionsRange.mockResolvedValue({
+  it("paginates in the joined session_accounts query", async () => {
+    mockSessionAccountsRange.mockResolvedValue({
       data: [
         {
-          id: "session-2",
-          status: "matched",
-          creator_display_name: "Sam",
-          invitee_display_name: "Taylor",
-          created_at: "2026-04-12T18:00:00Z",
-          expires_at: "2026-04-14T18:00:00Z",
-          matched_venue_id: null,
-          matched_at: "2026-04-12T20:00:00Z",
+          session_id: "session-2",
+          role: "b",
+          sessions: {
+            id: "session-2",
+            status: "matched",
+            creator_display_name: "Sam",
+            invitee_display_name: "Taylor",
+            created_at: "2026-04-12T18:00:00Z",
+            expires_at: "2026-04-14T18:00:00Z",
+            matched_venue_id: null,
+            matched_at: "2026-04-12T20:00:00Z",
+          },
         },
       ],
       count: 2,
@@ -192,7 +196,7 @@ describe("session-history-service getHistory", () => {
 
     const result = await getHistory("account-1", 2, 1);
 
-    expect(mockSessionsRange).toHaveBeenCalledWith(1, 1);
+    expect(mockSessionAccountsRange).toHaveBeenCalledWith(1, 1);
     expect(result.page).toBe(2);
     expect(result.pageSize).toBe(1);
     expect(result.totalCount).toBe(2);

--- a/web-service/src/lib/services/__tests__/session-history-query-service.test.ts
+++ b/web-service/src/lib/services/__tests__/session-history-query-service.test.ts
@@ -4,8 +4,13 @@ import { getHistory } from "../session-history-service";
 const mockSessionAccountsEq = vi.fn();
 const mockSessionAccountsSelect = vi.fn(() => ({ eq: mockSessionAccountsEq }));
 
-const mockSessionsOrder = vi.fn();
-const mockSessionsIn = vi.fn(() => ({ order: mockSessionsOrder }));
+const mockSessionsRange = vi.fn();
+const mockSessionsOrder = vi.fn(() => ({ range: mockSessionsRange }));
+const mockSessionsEq = vi.fn(() => ({ order: mockSessionsOrder }));
+const mockSessionsIn = vi.fn(() => ({
+  eq: mockSessionsEq,
+  order: mockSessionsOrder,
+}));
 const mockSessionsSelect = vi.fn(() => ({ in: mockSessionsIn }));
 
 const mockVenuesIn = vi.fn();
@@ -38,12 +43,12 @@ describe("session-history-service getHistory", () => {
     vi.clearAllMocks();
     mockSessionAccountsEq.mockResolvedValue({
       data: [
-        { session_id: "session-1", account_id: "account-1", role: "a", linked_at: "2026-04-13T20:00:00Z" },
-        { session_id: "session-2", account_id: "account-1", role: "b", linked_at: "2026-04-12T20:00:00Z" },
+        { session_id: "session-1", role: "a" },
+        { session_id: "session-2", role: "b" },
       ],
       error: null,
     });
-    mockSessionsOrder.mockResolvedValue({
+    mockSessionsRange.mockResolvedValue({
       data: [
         {
           id: "session-1",
@@ -55,17 +60,8 @@ describe("session-history-service getHistory", () => {
           matched_venue_id: "venue-1",
           matched_at: "2026-04-13T20:00:00Z",
         },
-        {
-          id: "session-2",
-          status: "expired",
-          creator_display_name: "Sam",
-          invitee_display_name: "Taylor",
-          created_at: "2026-04-12T18:00:00Z",
-          expires_at: "2026-04-14T18:00:00Z",
-          matched_venue_id: null,
-          matched_at: null,
-        },
       ],
+      count: 1,
       error: null,
     });
     mockVenuesIn.mockResolvedValue({
@@ -104,6 +100,8 @@ describe("session-history-service getHistory", () => {
     expect(mockSessionAccountsEq).toHaveBeenCalledWith("account_id", "account-1");
     expect(mockFrom).toHaveBeenCalledWith("sessions");
     expect(mockSessionsIn).toHaveBeenCalledWith("id", ["session-1", "session-2"]);
+    expect(mockSessionsEq).toHaveBeenCalledWith("status", "matched");
+    expect(mockSessionsRange).toHaveBeenCalledWith(0, 9);
     expect(result).toEqual({
       sessions: [
         {
@@ -127,27 +125,7 @@ describe("session-history-service getHistory", () => {
   });
 
   it("supports includeAll to keep non-matched sessions in history", async () => {
-    const result = await getHistory("account-1", 1, 10, true);
-
-    expect(result.sessions).toHaveLength(2);
-    expect(result.sessions[1]).toEqual({
-      sessionId: "session-2",
-      status: "expired",
-      createdAt: "2026-04-12T18:00:00.000Z",
-      role: "b",
-      matchedVenue: null,
-    });
-  });
-
-  it("paginates after filtering", async () => {
-    mockSessionAccountsEq.mockResolvedValue({
-      data: [
-        { session_id: "session-1", account_id: "account-1", role: "a", linked_at: "2026-04-13T20:00:00Z" },
-        { session_id: "session-2", account_id: "account-1", role: "b", linked_at: "2026-04-12T20:00:00Z" },
-      ],
-      error: null,
-    });
-    mockSessionsOrder.mockResolvedValue({
+    mockSessionsRange.mockResolvedValue({
       data: [
         {
           id: "session-1",
@@ -161,6 +139,44 @@ describe("session-history-service getHistory", () => {
         },
         {
           id: "session-2",
+          status: "expired",
+          creator_display_name: "Sam",
+          invitee_display_name: "Taylor",
+          created_at: "2026-04-12T18:00:00Z",
+          expires_at: "2026-04-14T18:00:00Z",
+          matched_venue_id: null,
+          matched_at: null,
+        },
+      ],
+      count: 2,
+      error: null,
+    });
+
+    const result = await getHistory("account-1", 1, 10, true);
+
+    expect(mockSessionsEq).not.toHaveBeenCalled();
+    expect(result.sessions).toHaveLength(2);
+    expect(result.sessions[1]).toEqual({
+      sessionId: "session-2",
+      status: "expired",
+      createdAt: "2026-04-12T18:00:00.000Z",
+      role: "b",
+      matchedVenue: null,
+    });
+  });
+
+  it("paginates in the sessions query", async () => {
+    mockSessionAccountsEq.mockResolvedValue({
+      data: [
+        { session_id: "session-1", role: "a" },
+        { session_id: "session-2", role: "b" },
+      ],
+      error: null,
+    });
+    mockSessionsRange.mockResolvedValue({
+      data: [
+        {
+          id: "session-2",
           status: "matched",
           creator_display_name: "Sam",
           invitee_display_name: "Taylor",
@@ -170,11 +186,13 @@ describe("session-history-service getHistory", () => {
           matched_at: "2026-04-12T20:00:00Z",
         },
       ],
+      count: 2,
       error: null,
     });
 
     const result = await getHistory("account-1", 2, 1);
 
+    expect(mockSessionsRange).toHaveBeenCalledWith(1, 1);
     expect(result.page).toBe(2);
     expect(result.pageSize).toBe(1);
     expect(result.totalCount).toBe(2);

--- a/web-service/src/lib/services/__tests__/session-history-service.test.ts
+++ b/web-service/src/lib/services/__tests__/session-history-service.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { linkSessionToAccount } from "../session-history-service";
+
+const mockInsert = vi.fn();
+const mockFrom = vi.fn(() => ({ insert: mockInsert }));
+
+vi.mock("../../supabase-server", () => ({
+  getSupabaseServerClient: () => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  }),
+}));
+
+describe("session-history-service linkSessionToAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInsert.mockResolvedValue({ error: null });
+  });
+
+  it("creates a session_accounts row for the authenticated account", async () => {
+    await linkSessionToAccount("session-1", "account-1", "b");
+
+    expect(mockFrom).toHaveBeenCalledWith("session_accounts");
+    expect(mockInsert).toHaveBeenCalledWith({
+      session_id: "session-1",
+      account_id: "account-1",
+      role: "b",
+    });
+  });
+
+  it("throws when the join insert fails", async () => {
+    mockInsert.mockResolvedValue({
+      error: { message: "insert failed" },
+    });
+
+    await expect(
+      linkSessionToAccount("session-1", "account-1", "a"),
+    ).rejects.toThrow("insert failed");
+  });
+});

--- a/web-service/src/lib/services/account-service.ts
+++ b/web-service/src/lib/services/account-service.ts
@@ -23,6 +23,28 @@ function mapLoginError(message: string): string {
   return message;
 }
 
+async function resolveSessionToken(
+  email: string,
+  password: string,
+  accessToken: string | undefined,
+): Promise<string> {
+  if (accessToken) {
+    return accessToken;
+  }
+
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error || !data.session?.access_token) {
+    throw new Error("Check your email to confirm your account");
+  }
+
+  return data.session.access_token;
+}
+
 export async function register(
   email: string,
   password: string,
@@ -39,9 +61,15 @@ export async function register(
     throw new Error(mapRegisterError(error.message));
   }
 
-  if (!data.user || !data.session?.access_token) {
+  if (!data.user) {
     throw new Error("Unable to create account");
   }
+
+  const token = await resolveSessionToken(
+    email,
+    password,
+    data.session?.access_token,
+  );
 
   const { data: accountRow, error: accountError } = await serverSupabase
     .from("accounts")
@@ -57,7 +85,7 @@ export async function register(
   }
 
   return {
-    token: data.session.access_token,
+    token,
     account: toAccount(accountRow),
   };
 }
@@ -112,6 +140,26 @@ export async function beginGoogleOAuth(
 
   if (!data.url) {
     throw new Error("Unable to start Google OAuth");
+  }
+
+  return data.url;
+}
+
+export async function beginAppleOAuth(
+  redirectTo?: string,
+): Promise<string> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "apple",
+    options: redirectTo ? { redirectTo } : undefined,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data.url) {
+    throw new Error("Unable to start Apple OAuth");
   }
 
   return data.url;

--- a/web-service/src/lib/services/account-service.ts
+++ b/web-service/src/lib/services/account-service.ts
@@ -95,6 +95,7 @@ export async function login(
   password: string,
 ): Promise<AuthResult> {
   const supabase = getSupabaseClient();
+  const serverSupabase = getSupabaseServerClient();
 
   const { data, error } = await supabase.auth.signInWithPassword({
     email,
@@ -109,7 +110,7 @@ export async function login(
     throw new Error("Invalid credentials");
   }
 
-  const { data: accountRow, error: accountError } = await supabase
+  const { data: accountRow, error: accountError } = await serverSupabase
     .from("accounts")
     .select()
     .eq("id", data.user.id)
@@ -169,6 +170,7 @@ export async function getAccountByAccessToken(
   token: string,
 ): Promise<Account> {
   const supabase = getSupabaseClient();
+  const serverSupabase = getSupabaseServerClient();
   const {
     data: { user },
     error: authError,
@@ -178,7 +180,7 @@ export async function getAccountByAccessToken(
     throw new Error("Invalid token");
   }
 
-  const { data: accountRow, error: accountError } = await supabase
+  const { data: accountRow, error: accountError } = await serverSupabase
     .from("accounts")
     .select()
     .eq("id", user.id)

--- a/web-service/src/lib/services/account-service.ts
+++ b/web-service/src/lib/services/account-service.ts
@@ -1,0 +1,144 @@
+import { getSupabaseClient } from "../supabase";
+import { getSupabaseServerClient } from "../supabase-server";
+import { toAccount, type Account } from "../types/account";
+
+export type AuthResult = {
+  readonly account: Account;
+  readonly token: string;
+};
+
+function mapRegisterError(message: string): string {
+  if (message.toLowerCase().includes("already registered")) {
+    return "Email already registered";
+  }
+
+  return message;
+}
+
+function mapLoginError(message: string): string {
+  if (message.toLowerCase().includes("invalid login credentials")) {
+    return "Invalid credentials";
+  }
+
+  return message;
+}
+
+export async function register(
+  email: string,
+  password: string,
+): Promise<AuthResult> {
+  const supabase = getSupabaseClient();
+  const serverSupabase = getSupabaseServerClient();
+
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+  });
+
+  if (error) {
+    throw new Error(mapRegisterError(error.message));
+  }
+
+  if (!data.user || !data.session?.access_token) {
+    throw new Error("Unable to create account");
+  }
+
+  const { data: accountRow, error: accountError } = await serverSupabase
+    .from("accounts")
+    .insert({
+      id: data.user.id,
+      email: data.user.email ?? email,
+    })
+    .select()
+    .single();
+
+  if (accountError) {
+    throw new Error(accountError.message);
+  }
+
+  return {
+    token: data.session.access_token,
+    account: toAccount(accountRow),
+  };
+}
+
+export async function login(
+  email: string,
+  password: string,
+): Promise<AuthResult> {
+  const supabase = getSupabaseClient();
+
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    throw new Error(mapLoginError(error.message));
+  }
+
+  if (!data.user || !data.session?.access_token) {
+    throw new Error("Invalid credentials");
+  }
+
+  const { data: accountRow, error: accountError } = await supabase
+    .from("accounts")
+    .select()
+    .eq("id", data.user.id)
+    .single();
+
+  if (accountError) {
+    throw new Error(accountError.message);
+  }
+
+  return {
+    token: data.session.access_token,
+    account: toAccount(accountRow),
+  };
+}
+
+export async function beginGoogleOAuth(
+  redirectTo?: string,
+): Promise<string> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "google",
+    options: redirectTo ? { redirectTo } : undefined,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data.url) {
+    throw new Error("Unable to start Google OAuth");
+  }
+
+  return data.url;
+}
+
+export async function getAccountByAccessToken(
+  token: string,
+): Promise<Account> {
+  const supabase = getSupabaseClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser(token);
+
+  if (authError || !user) {
+    throw new Error("Invalid token");
+  }
+
+  const { data: accountRow, error: accountError } = await supabase
+    .from("accounts")
+    .select()
+    .eq("id", user.id)
+    .single();
+
+  if (accountError) {
+    throw new Error(accountError.message);
+  }
+
+  return toAccount(accountRow);
+}

--- a/web-service/src/lib/services/session-history-service.ts
+++ b/web-service/src/lib/services/session-history-service.ts
@@ -23,9 +23,7 @@ export async function linkSessionToAccount(
 
 type SessionAccountLinkRow = {
   readonly session_id: string;
-  readonly account_id: string;
   readonly role: SessionAccountRole;
-  readonly linked_at: string;
 };
 
 export type HistorySession = {
@@ -58,7 +56,7 @@ export async function getHistory(
   const supabase = getSupabaseServerClient();
   const { data: linkRows, error: linksError } = await supabase
     .from("session_accounts")
-    .select()
+    .select("session_id, role")
     .eq("account_id", accountId);
 
   if (linksError) {
@@ -78,22 +76,31 @@ export async function getHistory(
     };
   }
 
-  const { data: sessionRows, error: sessionsError } = await supabase
+  const startIndex = (page - 1) * pageSize;
+  const endIndex = startIndex + pageSize - 1;
+  let sessionQuery = supabase
     .from("sessions")
-    .select()
-    .in("id", sessionIds)
-    .order("created_at", { ascending: false });
+    .select("*", { count: "exact" })
+    .in("id", sessionIds);
+
+  if (!includeAll) {
+    sessionQuery = sessionQuery.eq("status", "matched");
+  }
+
+  const {
+    data: sessionRows,
+    error: sessionsError,
+    count,
+  } = await sessionQuery
+    .order("created_at", { ascending: false })
+    .range(startIndex, endIndex);
 
   if (sessionsError) {
     throw new Error(sessionsError.message);
   }
 
-  const sessions = (sessionRows ?? []) as SessionRow[];
-  const visibleSessions = includeAll
-    ? sessions
-    : sessions.filter((session) => session.status === "matched");
-
-  const matchedVenueIds = visibleSessions
+  const pagedSessions = (sessionRows ?? []) as SessionRow[];
+  const matchedVenueIds = pagedSessions
     .map((session) => session.matched_venue_id)
     .filter((value): value is string => typeof value === "string");
 
@@ -118,10 +125,8 @@ export async function getHistory(
     links.map((row) => [row.session_id, row.role] as const),
   );
 
-  const totalCount = visibleSessions.length;
+  const totalCount = count ?? 0;
   const totalPages = totalCount === 0 ? 0 : Math.ceil(totalCount / pageSize);
-  const startIndex = (page - 1) * pageSize;
-  const pagedSessions = visibleSessions.slice(startIndex, startIndex + pageSize);
 
   return {
     sessions: pagedSessions.map((session) => {

--- a/web-service/src/lib/services/session-history-service.ts
+++ b/web-service/src/lib/services/session-history-service.ts
@@ -24,6 +24,7 @@ export async function linkSessionToAccount(
 type SessionAccountLinkRow = {
   readonly session_id: string;
   readonly role: SessionAccountRole;
+  readonly sessions: SessionRow | SessionRow[] | null;
 };
 
 export type HistorySession = {
@@ -54,19 +55,46 @@ export async function getHistory(
   includeAll = false,
 ): Promise<SessionHistoryPage> {
   const supabase = getSupabaseServerClient();
-  const { data: linkRows, error: linksError } = await supabase
+  const startIndex = (page - 1) * pageSize;
+  const endIndex = startIndex + pageSize - 1;
+  let historyQuery = supabase
     .from("session_accounts")
-    .select("session_id, role")
+    .select("session_id, role, sessions!inner(*)", { count: "exact" })
     .eq("account_id", accountId);
+
+  if (!includeAll) {
+    historyQuery = historyQuery.eq("sessions.status", "matched");
+  }
+
+  const {
+    data: linkRows,
+    error: linksError,
+    count,
+  } = await historyQuery
+    .order("created_at", { ascending: false, referencedTable: "sessions" })
+    .range(startIndex, endIndex);
 
   if (linksError) {
     throw new Error(linksError.message);
   }
 
-  const links = (linkRows ?? []) as SessionAccountLinkRow[];
-  const sessionIds = links.map((row) => row.session_id);
+  const links = ((linkRows ?? []) as SessionAccountLinkRow[])
+    .map((row) => ({
+      sessionId: row.session_id,
+      role: row.role,
+      session: Array.isArray(row.sessions) ? (row.sessions[0] ?? null) : row.sessions,
+    }))
+    .filter(
+      (
+        row,
+      ): row is {
+        readonly sessionId: string;
+        readonly role: SessionAccountRole;
+        readonly session: SessionRow;
+      } => row.session !== null,
+    );
 
-  if (sessionIds.length === 0) {
+  if (links.length === 0) {
     return {
       sessions: [],
       page,
@@ -76,31 +104,8 @@ export async function getHistory(
     };
   }
 
-  const startIndex = (page - 1) * pageSize;
-  const endIndex = startIndex + pageSize - 1;
-  let sessionQuery = supabase
-    .from("sessions")
-    .select("*", { count: "exact" })
-    .in("id", sessionIds);
-
-  if (!includeAll) {
-    sessionQuery = sessionQuery.eq("status", "matched");
-  }
-
-  const {
-    data: sessionRows,
-    error: sessionsError,
-    count,
-  } = await sessionQuery
-    .order("created_at", { ascending: false })
-    .range(startIndex, endIndex);
-
-  if (sessionsError) {
-    throw new Error(sessionsError.message);
-  }
-
-  const pagedSessions = (sessionRows ?? []) as SessionRow[];
-  const matchedVenueIds = pagedSessions
+  const matchedVenueIds = links
+    .map((row) => row.session)
     .map((session) => session.matched_venue_id)
     .filter((value): value is string => typeof value === "string");
 
@@ -121,25 +126,21 @@ export async function getHistory(
     }
   }
 
-  const roleBySessionId = new Map(
-    links.map((row) => [row.session_id, row.role] as const),
-  );
-
   const totalCount = count ?? 0;
   const totalPages = totalCount === 0 ? 0 : Math.ceil(totalCount / pageSize);
 
   return {
-    sessions: pagedSessions.map((session) => {
+    sessions: links.map(({ sessionId, role, session }) => {
       const matchedVenue =
         session.matched_venue_id === null
           ? null
           : venueMap.get(session.matched_venue_id) ?? null;
 
       return {
-        sessionId: session.id,
+        sessionId,
         status: session.status,
         createdAt: new Date(session.created_at).toISOString(),
-        role: roleBySessionId.get(session.id) ?? "a",
+        role,
         matchedVenue: matchedVenue
           ? {
               name: matchedVenue.name,

--- a/web-service/src/lib/services/session-history-service.ts
+++ b/web-service/src/lib/services/session-history-service.ts
@@ -1,0 +1,153 @@
+import { getSupabaseServerClient } from "../supabase-server";
+import type { SessionAccountRole } from "../types/account";
+import type { SessionRow } from "../types/session";
+import type { VenueRow } from "../types/venue";
+import { toVenue } from "../types/venue";
+
+export async function linkSessionToAccount(
+  sessionId: string,
+  accountId: string,
+  role: SessionAccountRole,
+): Promise<void> {
+  const supabase = getSupabaseServerClient();
+  const { error } = await supabase.from("session_accounts").insert({
+    session_id: sessionId,
+    account_id: accountId,
+    role,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+type SessionAccountLinkRow = {
+  readonly session_id: string;
+  readonly account_id: string;
+  readonly role: SessionAccountRole;
+  readonly linked_at: string;
+};
+
+export type HistorySession = {
+  readonly sessionId: string;
+  readonly status: SessionRow["status"];
+  readonly createdAt: string;
+  readonly role: SessionAccountRole;
+  readonly matchedVenue: {
+    readonly name: string;
+    readonly category: VenueRow["category"];
+    readonly address: string;
+    readonly photoUrl: string | null;
+  } | null;
+};
+
+export type SessionHistoryPage = {
+  readonly sessions: readonly HistorySession[];
+  readonly page: number;
+  readonly pageSize: number;
+  readonly totalCount: number;
+  readonly totalPages: number;
+};
+
+export async function getHistory(
+  accountId: string,
+  page: number,
+  pageSize: number,
+  includeAll = false,
+): Promise<SessionHistoryPage> {
+  const supabase = getSupabaseServerClient();
+  const { data: linkRows, error: linksError } = await supabase
+    .from("session_accounts")
+    .select()
+    .eq("account_id", accountId);
+
+  if (linksError) {
+    throw new Error(linksError.message);
+  }
+
+  const links = (linkRows ?? []) as SessionAccountLinkRow[];
+  const sessionIds = links.map((row) => row.session_id);
+
+  if (sessionIds.length === 0) {
+    return {
+      sessions: [],
+      page,
+      pageSize,
+      totalCount: 0,
+      totalPages: 0,
+    };
+  }
+
+  const { data: sessionRows, error: sessionsError } = await supabase
+    .from("sessions")
+    .select()
+    .in("id", sessionIds)
+    .order("created_at", { ascending: false });
+
+  if (sessionsError) {
+    throw new Error(sessionsError.message);
+  }
+
+  const sessions = (sessionRows ?? []) as SessionRow[];
+  const visibleSessions = includeAll
+    ? sessions
+    : sessions.filter((session) => session.status === "matched");
+
+  const matchedVenueIds = visibleSessions
+    .map((session) => session.matched_venue_id)
+    .filter((value): value is string => typeof value === "string");
+
+  const venueMap = new Map<string, ReturnType<typeof toVenue>>();
+
+  if (matchedVenueIds.length > 0) {
+    const { data: venueRows, error: venuesError } = await supabase
+      .from("venues")
+      .select()
+      .in("id", matchedVenueIds);
+
+    if (venuesError) {
+      throw new Error(venuesError.message);
+    }
+
+    for (const row of (venueRows ?? []) as VenueRow[]) {
+      venueMap.set(row.id, toVenue(row));
+    }
+  }
+
+  const roleBySessionId = new Map(
+    links.map((row) => [row.session_id, row.role] as const),
+  );
+
+  const totalCount = visibleSessions.length;
+  const totalPages = totalCount === 0 ? 0 : Math.ceil(totalCount / pageSize);
+  const startIndex = (page - 1) * pageSize;
+  const pagedSessions = visibleSessions.slice(startIndex, startIndex + pageSize);
+
+  return {
+    sessions: pagedSessions.map((session) => {
+      const matchedVenue =
+        session.matched_venue_id === null
+          ? null
+          : venueMap.get(session.matched_venue_id) ?? null;
+
+      return {
+        sessionId: session.id,
+        status: session.status,
+        createdAt: new Date(session.created_at).toISOString(),
+        role: roleBySessionId.get(session.id) ?? "a",
+        matchedVenue: matchedVenue
+          ? {
+              name: matchedVenue.name,
+              category: matchedVenue.category,
+              address: matchedVenue.address,
+              photoUrl: matchedVenue.photoUrl,
+            }
+          : null,
+      };
+    }),
+    page,
+    pageSize,
+    totalCount,
+    totalPages,
+  };
+}

--- a/web-service/src/lib/session-link-storage.ts
+++ b/web-service/src/lib/session-link-storage.ts
@@ -1,0 +1,53 @@
+import type { Role } from "./types/preference";
+
+export const DATEFLOW_SESSION_LINK_KEY = "dateflow:session-link";
+
+export type StoredSessionLink = {
+  readonly sessionId: string;
+  readonly role: Role;
+};
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export function persistSessionLink(
+  storage: StorageLike,
+  value: StoredSessionLink,
+): void {
+  storage.setItem(DATEFLOW_SESSION_LINK_KEY, JSON.stringify(value));
+}
+
+export function loadStoredSessionLink(
+  storage: StorageLike,
+): StoredSessionLink | null {
+  const raw = storage.getItem(DATEFLOW_SESSION_LINK_KEY);
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.sessionId === "string" &&
+      (parsed.role === "a" || parsed.role === "b")
+    ) {
+      return {
+        sessionId: parsed.sessionId,
+        role: parsed.role,
+      };
+    }
+  } catch {
+    storage.removeItem(DATEFLOW_SESSION_LINK_KEY);
+    return null;
+  }
+
+  storage.removeItem(DATEFLOW_SESSION_LINK_KEY);
+  return null;
+}
+
+export function clearStoredSessionLink(storage: StorageLike): void {
+  storage.removeItem(DATEFLOW_SESSION_LINK_KEY);
+}

--- a/web-service/src/lib/types/__tests__/account.test.ts
+++ b/web-service/src/lib/types/__tests__/account.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  toAccount,
+  toSessionAccount,
+  type AccountRow,
+  type SessionAccountRow,
+} from "../account";
+
+describe("account types", () => {
+  it("maps an account row into the app account shape", () => {
+    const row: AccountRow = {
+      id: "account-1",
+      email: "alex@example.com",
+      created_at: "2026-04-13T18:45:00Z",
+    };
+
+    const account = toAccount(row);
+
+    expect(account).toEqual({
+      id: "account-1",
+      email: "alex@example.com",
+      createdAt: new Date("2026-04-13T18:45:00.000Z"),
+    });
+  });
+
+  it("maps a session_accounts row into the app join-record shape", () => {
+    const row: SessionAccountRow = {
+      session_id: "session-1",
+      account_id: "account-1",
+      role: "b",
+      linked_at: "2026-04-13T18:50:00Z",
+    };
+
+    const sessionAccount = toSessionAccount(row);
+
+    expect(sessionAccount).toEqual({
+      sessionId: "session-1",
+      accountId: "account-1",
+      role: "b",
+      linkedAt: new Date("2026-04-13T18:50:00.000Z"),
+    });
+  });
+});

--- a/web-service/src/lib/types/account.ts
+++ b/web-service/src/lib/types/account.ts
@@ -1,0 +1,44 @@
+export type Account = {
+  readonly id: string;
+  readonly email: string;
+  readonly createdAt: Date;
+};
+
+export type AccountRow = {
+  readonly id: string;
+  readonly email: string;
+  readonly created_at: string;
+};
+
+export function toAccount(row: AccountRow): Account {
+  return {
+    id: row.id,
+    email: row.email,
+    createdAt: new Date(row.created_at),
+  };
+}
+
+export type SessionAccountRole = "a" | "b";
+
+export type SessionAccount = {
+  readonly sessionId: string;
+  readonly accountId: string;
+  readonly role: SessionAccountRole;
+  readonly linkedAt: Date;
+};
+
+export type SessionAccountRow = {
+  readonly session_id: string;
+  readonly account_id: string;
+  readonly role: SessionAccountRole;
+  readonly linked_at: string;
+};
+
+export function toSessionAccount(row: SessionAccountRow): SessionAccount {
+  return {
+    sessionId: row.session_id,
+    accountId: row.account_id,
+    role: row.role,
+    linkedAt: new Date(row.linked_at),
+  };
+}

--- a/web-service/supabase/migrations/011_create_accounts_and_session_accounts.sql
+++ b/web-service/supabase/migrations/011_create_accounts_and_session_accounts.sql
@@ -1,0 +1,19 @@
+-- DS-06: Session History — adds lightweight accounts plus a join table that
+-- links sessions to accounts without changing the accountless MVP session flow.
+
+CREATE TABLE accounts (
+  id uuid PRIMARY KEY,
+  email text NOT NULL UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE session_accounts (
+  session_id uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  account_id uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  role text NOT NULL CHECK (role IN ('a', 'b')),
+  linked_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (session_id, account_id)
+);
+
+CREATE INDEX idx_session_accounts_account
+  ON session_accounts (account_id);

--- a/web-service/supabase/migrations/012_secure_accounts_and_session_accounts.sql
+++ b/web-service/supabase/migrations/012_secure_accounts_and_session_accounts.sql
@@ -1,0 +1,10 @@
+-- DS-06 follow-up: secure account-linked history tables and preserve one
+-- account per session role.
+
+ALTER TABLE accounts ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE session_accounts ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE session_accounts
+  ADD CONSTRAINT session_accounts_session_id_role_key
+  UNIQUE (session_id, role);


### PR DESCRIPTION
## Summary
- add the DS-06 accounts schema, auth services, and authenticated routes for register, login, account lookup, and session history
- add the result-page save prompt, auth sheet, token and session-link storage, and Google OAuth hydration for signed-in state
- add the `/history` frontend with filters, load-more pagination, account header, motion polish, and focused regression coverage

## Test plan
- [x] `cd web-service && bunx vitest run 'src/lib/services/__tests__/account-service.test.ts' 'src/app/api/auth/me/__tests__/route.test.ts' 'src/lib/__tests__/auth-client.test.ts' 'src/app/history/__tests__/history-page-state.test.ts' 'src/app/history/__tests__/history-page-oauth-state.test.ts' 'src/app/history/__tests__/history-page.test.tsx' 'src/app/history/__tests__/page.test.tsx'`
- [x] `cd web-service && bunx eslint 'src/lib/services/account-service.ts' 'src/app/api/auth/me/route.ts' 'src/lib/auth-client.ts' 'src/app/history/history-page.tsx' 'src/lib/services/__tests__/account-service.test.ts' 'src/app/api/auth/me/__tests__/route.test.ts' 'src/lib/__tests__/auth-client.test.ts'`
- [x] `cd web-service && ~/.codex/bin/tdd-lock verify`