### PR TITLE
Redesign Person A & B landing pages

### DIFF
--- a/web-service/src/app/plan/[id]/plan-flow.tsx
+++ b/web-service/src/app/plan/[id]/plan-flow.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { HookScreen } from "../../../components/hook-screen";
-import { LocationScreen } from "../../../components/location-screen";
-import { VibeScreen } from "../../../components/vibe-screen";
 import { LoadingScreen } from "../../../components/loading-screen";
 import { createSessionStatusSync } from "../../../lib/session-status-sync";
 import type { Location, BudgetLevel, Category } from "../../../lib/types/preference";
@@ -20,14 +18,11 @@ type PlanFlowProps = {
 /**
  * Client-side flow orchestrator for the Person B experience.
  *
- * Manages which screen is visible (hook → location → vibe → loading)
- * and holds the collected preference data as it accumulates across screens.
- *
- * When Person B completes the vibe screen, PlanFlow bundles all collected
- * data (location + categories + budget) and POSTs it to the preferences API.
- * The loading screen renders immediately while the request is in flight.
+ * HookScreen collects display name, location, categories, and budget on a
+ * single landing, then PlanFlow POSTs the bundled preferences and shows
+ * the loading screen while the session transitions.
  */
-type FlowStep = "hook" | "location" | "vibe" | "loading";
+type FlowStep = "hook" | "loading";
 
 export function PlanFlow({
   sessionId,
@@ -112,31 +107,6 @@ export function PlanFlow({
     );
   }
 
-  if (step === "location") {
-    return (
-      <LocationScreen
-        onComplete={(loc) => {
-          setLocation(loc);
-          setStep("vibe");
-        }}
-        onBack={() => setStep("hook")}
-      />
-    );
-  }
-
-  if (step === "vibe") {
-    return (
-      <VibeScreen
-        onComplete={(vibeData) => {
-          if (!location) return;
-          setStep("loading");
-          submitPreferences(location, vibeData.categories, vibeData.budget);
-        }}
-        onBack={() => setStep("hook")}
-      />
-    );
-  }
-
   // step === "loading"
   if (submitError) {
     return (
@@ -146,7 +116,7 @@ export function PlanFlow({
           <button
             onClick={() => {
               setSubmitError(null);
-              setStep("vibe");
+              setStep("hook");
             }}
             className="cursor-pointer text-body font-medium text-secondary underline underline-offset-2"
           >

--- a/web-service/src/app/plan/[id]/plan-flow.tsx
+++ b/web-service/src/app/plan/[id]/plan-flow.tsx
@@ -100,9 +100,11 @@ export function PlanFlow({
         <HookScreen
           creatorName={creatorName}
           initialDisplayName={inviteeDisplayName}
-          onContinue={(displayName) => {
+          initialLocation={location}
+          onContinue={(displayName, hookLocation) => {
             setInviteeDisplayName(displayName);
-            setStep("location");
+            setLocation(hookLocation);
+            setStep("vibe");
           }}
       />
     );
@@ -128,7 +130,7 @@ export function PlanFlow({
           setStep("loading");
           submitPreferences(location, vibeData.categories, vibeData.budget);
         }}
-        onBack={() => setStep("location")}
+        onBack={() => setStep("hook")}
       />
     );
   }

--- a/web-service/src/app/plan/[id]/plan-flow.tsx
+++ b/web-service/src/app/plan/[id]/plan-flow.tsx
@@ -44,7 +44,8 @@ export function PlanFlow({
   async function submitPreferences(
     loc: Location,
     vibeCategories: Category[],
-    vibeBudget: BudgetLevel
+    vibeBudget: BudgetLevel,
+    displayNameOverride?: string,
   ) {
     try {
       const response = await fetch(
@@ -54,7 +55,7 @@ export function PlanFlow({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             role: "b",
-            displayName: inviteeDisplayName,
+            displayName: displayNameOverride ?? inviteeDisplayName,
             location: { lat: loc.lat, lng: loc.lng, label: loc.label },
             budget: vibeBudget,
             categories: vibeCategories,
@@ -97,15 +98,16 @@ export function PlanFlow({
 
   if (step === "hook") {
     return (
-        <HookScreen
-          creatorName={creatorName}
-          initialDisplayName={inviteeDisplayName}
-          initialLocation={location}
-          onContinue={(displayName, hookLocation) => {
-            setInviteeDisplayName(displayName);
-            setLocation(hookLocation);
-            setStep("vibe");
-          }}
+      <HookScreen
+        creatorName={creatorName}
+        initialDisplayName={inviteeDisplayName}
+        initialLocation={location}
+        onContinue={(data) => {
+          setInviteeDisplayName(data.displayName);
+          setLocation(data.location);
+          setStep("loading");
+          submitPreferences(data.location, data.categories, data.budget, data.displayName);
+        }}
       />
     );
   }

--- a/web-service/src/components/budget-icon.tsx
+++ b/web-service/src/components/budget-icon.tsx
@@ -1,0 +1,63 @@
+import type { BudgetLevel } from "../lib/types/preference";
+
+type BudgetIconProps = {
+  readonly budget: BudgetLevel;
+  readonly className?: string;
+};
+
+export function BudgetIcon({ budget, className = "h-4 w-4" }: BudgetIconProps) {
+  if (budget === "BUDGET") {
+    return (
+      <svg
+        className={className}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M4 9h12v6a4 4 0 0 1-4 4H8a4 4 0 0 1-4-4V9Z" />
+        <path d="M16 10h2a2 2 0 0 1 2 2v1a2 2 0 0 1-2 2h-2" />
+        <path d="M8 3c0 1 1 1.5 1 3" />
+        <path d="M12 3c0 1 1 1.5 1 3" />
+      </svg>
+    );
+  }
+
+  if (budget === "MODERATE") {
+    return (
+      <svg
+        className={className}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M6 3v7a2 2 0 0 0 2 2v9" />
+        <path d="M10 3v7a2 2 0 0 1-2 2" />
+        <path d="M16 3c-1.5 0-3 2-3 5s1.5 5 3 5v8" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3l1.8 4.7L18.5 9l-4.7 1.8L12 15l-1.8-4.2L5.5 9l4.7-1.3L12 3Z" />
+      <path d="M18 15l.7 1.8L20.5 17.5l-1.8.7L18 20l-.7-1.8L15.5 17.5l1.8-.7L18 15Z" />
+    </svg>
+  );
+}

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -29,12 +29,14 @@ const BUDGETS: { value: BudgetLevel; label: string }[] = [
   { value: "UPSCALE", label: "Upscale" },
 ];
 
+const INK = "#3d0e1f";
+
 /**
  * Person B landing — single-page invitation flow.
  *
- * Mirrors the Person A form pattern (translucent card on a rich gradient)
- * but in a saturated pink palette. Collects name, area, formats, and
- * budget before handing off to the loading screen.
+ * Petal pastel gradient with dark-ink type. Mirrors the Person A form
+ * pattern: translucent card with Name, Location, Categories, Budget, and
+ * Surprise me, then hands off to the loading screen.
  */
 export function HookScreen({
   creatorName,
@@ -114,40 +116,43 @@ export function HookScreen({
   }
 
   return (
-    <main className="relative min-h-dvh overflow-hidden bg-[radial-gradient(circle_at_top,_#a83358_0%,_#6a1a36_55%,_#3d0e1f_100%)] text-white">
+    <main
+      className="relative min-h-dvh overflow-hidden bg-[radial-gradient(circle_at_top,_#f8cbd3_0%,_#e8a5b4_55%,_#c47a8e_100%)]"
+      style={{ color: INK }}
+    >
       <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-6 pb-10 pt-8">
-        <p className="text-caption font-semibold uppercase tracking-[0.28em] text-white">
+        <p className="text-caption font-semibold uppercase tracking-[0.28em]">
           Dateflow
         </p>
 
-        <div className="mt-8 flex items-center gap-4 rounded-[1.5rem] border border-white/15 bg-white/[0.08] p-4 shadow-[0_20px_40px_rgba(0,0,0,0.25)] backdrop-blur-sm">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white/90 text-lg font-bold text-[#6a1a36]">
+        <div className="mt-8 flex items-center gap-4 rounded-[1.5rem] border border-[#3d0e1f]/10 bg-white/50 p-4 shadow-[0_20px_40px_rgba(61,14,31,0.12)] backdrop-blur-sm">
+          <div
+            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-lg font-bold text-white"
+            style={{ background: INK }}
+          >
             {initial}
           </div>
           <div>
-            <p className="text-caption font-bold uppercase tracking-[0.14em] text-white/80">
+            <p className="text-caption font-bold uppercase tracking-[0.14em] opacity-70">
               You&apos;re invited
             </p>
-            <p className="mt-1 text-body font-semibold leading-tight text-white">
+            <p className="mt-1 text-body font-semibold leading-tight">
               {creatorName} invited you to pick the vibe
             </p>
           </div>
         </div>
 
-        <h1 className="mt-10 text-[clamp(2.4rem,8vw,3.2rem)] font-bold leading-[0.98] tracking-[-0.03em] text-white">
+        <h1 className="mt-10 text-[clamp(2.4rem,8vw,3.2rem)] font-bold leading-[0.98] tracking-[-0.03em]">
           Let&apos;s find what works for both of you
         </h1>
-        <p className="mt-5 text-body text-white/65">
+        <p className="mt-5 text-body opacity-70">
           Add your preferences and Dateflow will find where you both align.
         </p>
 
-        <div className="mt-8 rounded-[1.75rem] border border-white/10 bg-white/[0.06] p-5 shadow-[0_24px_60px_rgba(0,0,0,0.3)] backdrop-blur-sm">
+        <div className="mt-8 rounded-[1.75rem] border border-[#3d0e1f]/10 bg-white/45 p-5 shadow-[0_24px_60px_rgba(61,14,31,0.12)] backdrop-blur-sm">
           <div className="space-y-5">
             <div>
-              <label
-                htmlFor="invitee-display-name"
-                className="block text-body font-semibold text-white"
-              >
+              <label htmlFor="invitee-display-name" className="block text-body font-semibold">
                 Your Name
               </label>
               <input
@@ -157,22 +162,20 @@ export function HookScreen({
                 value={displayName}
                 onChange={(event) => setDisplayName(event.target.value)}
                 placeholder="Alex"
-                className="mt-3 h-12 w-full rounded-xl border border-white/15 bg-transparent px-4 text-body text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+                className="mt-3 h-12 w-full rounded-xl border border-[#3d0e1f]/15 bg-white/60 px-4 text-body placeholder:text-[#3d0e1f]/40 focus:border-[#3d0e1f]/50 focus:outline-none"
+                style={{ color: INK }}
               />
             </div>
 
             <div>
               <div className="flex items-center justify-between gap-3">
-                <label
-                  htmlFor="invitee-location"
-                  className="block text-body font-semibold text-white"
-                >
+                <label htmlFor="invitee-location" className="block text-body font-semibold">
                   Location
                 </label>
                 <button
                   type="button"
                   onClick={handleUseLocation}
-                  className="cursor-pointer text-caption font-semibold text-white/80 transition-colors hover:text-white"
+                  className="cursor-pointer text-caption font-semibold opacity-70 transition-opacity hover:opacity-100"
                 >
                   {gpsState === "loading" ? "Finding you..." : "Use my location"}
                 </button>
@@ -186,12 +189,13 @@ export function HookScreen({
                   setLocationLabel(event.target.value);
                 }}
                 placeholder="Brooklyn or 11211"
-                className="mt-3 h-12 w-full rounded-xl border border-white/15 bg-transparent px-4 text-body text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+                className="mt-3 h-12 w-full rounded-xl border border-[#3d0e1f]/15 bg-white/60 px-4 text-body placeholder:text-[#3d0e1f]/40 focus:border-[#3d0e1f]/50 focus:outline-none"
+                style={{ color: INK }}
               />
             </div>
 
             <div>
-              <p className="text-body font-semibold text-white">Categories</p>
+              <p className="text-body font-semibold">Categories</p>
               <div className="mt-3 grid grid-cols-2 gap-3">
                 {CATEGORIES.map((category) => {
                   const selected = categories.includes(category.value);
@@ -202,9 +206,10 @@ export function HookScreen({
                       onClick={() => toggleCategory(category.value)}
                       className={`h-14 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
-                          ? "border-white/60 bg-white/15 text-white"
-                          : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
+                          ? "border-[#3d0e1f]/60 bg-[#3d0e1f]/10"
+                          : "border-[#3d0e1f]/15 bg-white/55 hover:border-[#3d0e1f]/35"
                       }`}
+                      style={{ color: INK }}
                     >
                       {category.label}
                     </button>
@@ -214,7 +219,7 @@ export function HookScreen({
             </div>
 
             <div>
-              <p className="text-body font-semibold text-white">Budget</p>
+              <p className="text-body font-semibold">Budget</p>
               <div className="mt-3 grid grid-cols-3 gap-3">
                 {BUDGETS.map((option) => {
                   const selected = budget === option.value;
@@ -225,9 +230,10 @@ export function HookScreen({
                       onClick={() => setBudget(option.value)}
                       className={`h-12 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
-                          ? "border-white/60 bg-white/15 text-white"
-                          : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
+                          ? "border-[#3d0e1f]/60 bg-[#3d0e1f]/10"
+                          : "border-[#3d0e1f]/15 bg-white/55 hover:border-[#3d0e1f]/35"
                       }`}
+                      style={{ color: INK }}
                     >
                       {option.label}
                     </button>
@@ -239,7 +245,8 @@ export function HookScreen({
             <button
               type="button"
               onClick={handleSurpriseMe}
-              className="flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/[0.04] text-body font-semibold text-white transition-colors hover:bg-white/10"
+              className="flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-[#3d0e1f]/20 bg-white/55 text-body font-semibold transition-colors hover:bg-white/70"
+              style={{ color: INK }}
             >
               <span aria-hidden>✨</span> Surprise me
             </button>

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -2,40 +2,81 @@
 
 import { useState } from "react";
 import { Button } from "./button";
+import type { Location } from "../lib/types/preference";
 
 type HookScreenProps = {
   readonly creatorName: string;
   readonly initialDisplayName?: string;
-  readonly onContinue: (displayName: string) => void;
+  readonly initialLocation?: Location | null;
+  readonly onContinue: (displayName: string, location: Location) => void;
 };
 
 /**
  * Person B landing — the invitation hook.
  *
- * A light, warm peach canvas with an invitation banner from Person A,
- * a welcoming headline, a single name field, and the "Join this date plan"
- * CTA. Location and vibe selections live on the next steps of the flow.
+ * Warm peach canvas. Collects display name and location (GPS or typed)
+ * before handing off to the vibe screen.
  */
 export function HookScreen({
   creatorName,
   initialDisplayName = "",
+  initialLocation = null,
   onContinue,
 }: HookScreenProps) {
   const [displayName, setDisplayName] = useState(initialDisplayName);
-  const [showError, setShowError] = useState(false);
-  const errorId = "invitee-display-name-error";
+  const [locationLabel, setLocationLabel] = useState(initialLocation?.label ?? "");
+  const [location, setLocation] = useState<Location | null>(initialLocation);
+  const [gpsState, setGpsState] = useState<"idle" | "loading">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [showNameError, setShowNameError] = useState(false);
+  const nameErrorId = "invitee-display-name-error";
   const initial = creatorName.trim().charAt(0).toUpperCase() || "?";
 
-  function handleContinue() {
-    const trimmed = displayName.trim();
-
-    if (!trimmed) {
-      setShowError(true);
+  function handleUseLocation() {
+    if (!navigator.geolocation) {
+      setError("Location access is unavailable in this browser.");
       return;
     }
 
-    setShowError(false);
-    onContinue(trimmed);
+    setError(null);
+    setGpsState("loading");
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setLocation({
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+          label: "Current Location",
+        });
+        setLocationLabel("Current Location");
+        setGpsState("idle");
+      },
+      () => {
+        setGpsState("idle");
+        setError("We couldn't access your location. Enter your city or zip instead.");
+      },
+    );
+  }
+
+  function handleContinue() {
+    const trimmed = displayName.trim();
+    const trimmedLocation = locationLabel.trim();
+
+    if (!trimmed) {
+      setShowNameError(true);
+      return;
+    }
+
+    if (!location && trimmedLocation.length === 0) {
+      setError("Add your area so we can find a fair midpoint.");
+      return;
+    }
+
+    const resolvedLocation: Location =
+      location ?? { lat: 0, lng: 0, label: trimmedLocation };
+
+    setShowNameError(false);
+    setError(null);
+    onContinue(trimmed, resolvedLocation);
   }
 
   return (
@@ -66,41 +107,74 @@ export function HookScreen({
           Add your preferences and Dateflow will find where you both align.
         </p>
 
-        <div className="mt-8 space-y-3">
-          <label
-            htmlFor="invitee-display-name"
-            className="block text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary"
-          >
-            Your name
-          </label>
-          <input
-            id="invitee-display-name"
-            name="invitee-display-name"
-            type="text"
-            autoComplete="given-name"
-            aria-invalid={showError}
-            aria-describedby={showError ? errorId : undefined}
-            value={displayName}
-            onChange={(event) => {
-              setDisplayName(event.target.value);
-              if (showError) {
-                setShowError(false);
-              }
-            }}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") {
-                event.preventDefault();
-                handleContinue();
-              }
-            }}
-            placeholder="What should Dateflow call you?"
-            className="h-14 w-full rounded-2xl border border-white/80 bg-white/80 px-4 text-body text-text shadow-sm outline-none transition placeholder:text-text-secondary/55 focus:border-primary focus:ring-2 focus:ring-primary/20"
-          />
-          {showError ? (
-            <p id={errorId} className="text-caption text-error">
-              Add your name so the shared result feels like both of you.
-            </p>
-          ) : null}
+        <div className="mt-8 space-y-5">
+          <div className="space-y-2">
+            <label
+              htmlFor="invitee-display-name"
+              className="block text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary"
+            >
+              Your name
+            </label>
+            <input
+              id="invitee-display-name"
+              name="invitee-display-name"
+              type="text"
+              autoComplete="given-name"
+              aria-invalid={showNameError}
+              aria-describedby={showNameError ? nameErrorId : undefined}
+              value={displayName}
+              onChange={(event) => {
+                setDisplayName(event.target.value);
+                if (showNameError) {
+                  setShowNameError(false);
+                }
+              }}
+              placeholder="What should Dateflow call you?"
+              className="h-14 w-full rounded-2xl border border-white/80 bg-white/80 px-4 text-body text-text shadow-sm outline-none transition placeholder:text-text-secondary/55 focus:border-primary focus:ring-2 focus:ring-primary/20"
+            />
+            {showNameError ? (
+              <p id={nameErrorId} className="text-caption text-error">
+                Add your name so the shared result feels like both of you.
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <label
+                htmlFor="invitee-location"
+                className="block text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary"
+              >
+                Your area
+              </label>
+              <button
+                type="button"
+                onClick={handleUseLocation}
+                className="cursor-pointer text-caption font-semibold text-primary transition-colors hover:text-primary-hover"
+              >
+                {gpsState === "loading" ? "Finding you..." : "Use my location"}
+              </button>
+            </div>
+            <input
+              id="invitee-location"
+              type="text"
+              value={locationLabel}
+              onChange={(event) => {
+                setLocation(null);
+                setLocationLabel(event.target.value);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  handleContinue();
+                }
+              }}
+              placeholder="Brooklyn or 11211"
+              className="h-14 w-full rounded-2xl border border-white/80 bg-white/80 px-4 text-body text-text shadow-sm outline-none transition placeholder:text-text-secondary/55 focus:border-primary focus:ring-2 focus:ring-primary/20"
+            />
+          </div>
+
+          {error ? <p className="text-caption text-error">{error}</p> : null}
         </div>
 
         <div className="mt-auto pt-10">

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { Button } from "./button";
+import { BudgetIcon } from "./budget-icon";
+import { CategoryIcon } from "./category-icon";
 import type { BudgetLevel, Category, Location } from "../lib/types/preference";
 
 type HookScreenProps = {
@@ -112,14 +113,14 @@ export function HookScreen({
   }
 
   return (
-    <main className="relative min-h-dvh overflow-hidden bg-[radial-gradient(circle_at_top,_#c23a7a_0%,_#7a1e4c_55%,_#3e0f26_100%)] text-white">
+    <main className="relative min-h-dvh overflow-hidden bg-[radial-gradient(circle_at_top,_#d03d6a_0%,_#8a2346_55%,_#4a1224_100%)] text-white">
       <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-6 pb-10 pt-8">
         <p className="text-caption font-semibold uppercase tracking-[0.28em] text-white">
           Dateflow
         </p>
 
         <div className="mt-8 flex items-center gap-4 rounded-[1.5rem] border border-white/15 bg-white/[0.08] p-4 shadow-[0_20px_40px_rgba(0,0,0,0.25)] backdrop-blur-sm">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white/90 text-lg font-bold text-[#7a1e4c]">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white/90 text-lg font-bold text-[#8a2346]">
             {initial}
           </div>
           <div>
@@ -192,12 +193,13 @@ export function HookScreen({
                       key={category.value}
                       type="button"
                       onClick={() => toggleCategory(category.value)}
-                      className={`h-14 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
+                      className={`flex h-14 items-center justify-center gap-2 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
                           ? "border-white/60 bg-white/15 text-white"
                           : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
                       }`}
                     >
+                      <CategoryIcon category={category.value} className="h-5 w-5" />
                       {category.label}
                     </button>
                   );
@@ -215,12 +217,13 @@ export function HookScreen({
                       key={option.value}
                       type="button"
                       onClick={() => setBudget(option.value)}
-                      className={`h-12 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
+                      className={`flex h-12 items-center justify-center gap-1.5 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
                           ? "border-white/60 bg-white/15 text-white"
                           : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
                       }`}
                     >
+                      <BudgetIcon budget={option.value} className="h-4 w-4" />
                       {option.label}
                     </button>
                   );
@@ -241,9 +244,24 @@ export function HookScreen({
         {error ? <p className="mt-4 text-body text-error">{error}</p> : null}
 
         <div className="mt-6">
-          <Button onClick={handleContinue} disabled={!canSubmit}>
-            Join this date plan
-          </Button>
+          <button
+            type="button"
+            onClick={handleContinue}
+            disabled={!canSubmit}
+            className={`group relative flex h-16 w-full items-center justify-center gap-2 overflow-hidden rounded-2xl text-[1.05rem] font-bold tracking-tight text-white transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80 ${
+              canSubmit
+                ? "cursor-pointer bg-[linear-gradient(135deg,_#ff8fa3_0%,_#ff5a86_45%,_#ff3d7f_100%)] shadow-[0_20px_40px_rgba(255,61,127,0.45),_0_0_0_1px_rgba(255,255,255,0.25)_inset] motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-[0_26px_50px_rgba(255,61,127,0.55),_0_0_0_1px_rgba(255,255,255,0.35)_inset] active:translate-y-0"
+                : "cursor-not-allowed bg-white/10 text-white/50 shadow-none"
+            }`}
+          >
+            <span className="relative z-10">Join this date plan</span>
+            {canSubmit ? (
+              <span
+                aria-hidden
+                className="pointer-events-none absolute inset-x-2 top-1 h-1/3 rounded-t-xl bg-white/25 blur-[2px]"
+              />
+            ) : null}
+          </button>
         </div>
       </div>
     </main>

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -95,7 +95,7 @@ export function HookScreen({
 
   function handleContinue() {
     if (!canSubmit) {
-      setError("Fill in your name, area, and at least one format.");
+      setError("Fill in your name, location, and select at least one category.");
       return;
     }
 
@@ -192,6 +192,7 @@ export function HookScreen({
                     <button
                       key={category.value}
                       type="button"
+                      aria-pressed={selected}
                       onClick={() => toggleCategory(category.value)}
                       className={`flex h-14 items-center justify-center gap-2 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
@@ -216,6 +217,7 @@ export function HookScreen({
                     <button
                       key={option.value}
                       type="button"
+                      aria-pressed={selected}
                       onClick={() => setBudget(option.value)}
                       className={`flex h-12 items-center justify-center gap-1.5 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { BudgetIcon } from "./budget-icon";
-import { Button } from "./button";
 import { CategoryIcon } from "./category-icon";
 import type { BudgetLevel, Category, Location } from "../lib/types/preference";
 
@@ -245,9 +244,33 @@ export function HookScreen({
         {error ? <p className="mt-4 text-body text-error">{error}</p> : null}
 
         <div className="mt-6">
-          <Button variant="secondary" onClick={handleContinue} disabled={!canSubmit}>
+          <button
+            type="button"
+            onClick={handleContinue}
+            disabled={!canSubmit}
+            className={`flex h-14 w-full items-center justify-center gap-2 rounded-2xl text-body font-semibold transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80 ${
+              canSubmit
+                ? "cursor-pointer bg-white text-[#4a1224] shadow-[0_18px_40px_rgba(255,61,127,0.35),_inset_0_1px_0_rgba(255,255,255,0.9)] motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-[0_22px_48px_rgba(255,61,127,0.45),_inset_0_1px_0_rgba(255,255,255,0.9)] active:translate-y-0"
+                : "cursor-not-allowed bg-white/20 text-white/50 shadow-none"
+            }`}
+          >
             Join this date plan
-          </Button>
+            {canSubmit ? (
+              <svg
+                className="h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14" />
+                <path d="m13 6 6 6-6 6" />
+              </svg>
+            ) : null}
+          </button>
         </div>
       </div>
     </main>

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { Button } from "./button";
-import { Logo } from "./logo";
 
 type HookScreenProps = {
   readonly creatorName: string;
@@ -11,14 +10,11 @@ type HookScreenProps = {
 };
 
 /**
- * Screen 1 — The hook.
+ * Person B landing — the invitation hook.
  *
- * "{Name} wants to plan your first date."
- * One sentence, one button, zero form fields.
- *
- * The decorative gradient blobs (coral + teal) fill the visual space
- * that FigmaMake couldn't generate. They sit behind the text at low
- * opacity, making the screen feel warm and designed rather than empty.
+ * A light, warm peach canvas with an invitation banner from Person A,
+ * a welcoming headline, a single name field, and the "Join this date plan"
+ * CTA. Location and vibe selections live on the next steps of the flow.
  */
 export function HookScreen({
   creatorName,
@@ -28,6 +24,7 @@ export function HookScreen({
   const [displayName, setDisplayName] = useState(initialDisplayName);
   const [showError, setShowError] = useState(false);
   const errorId = "invitee-display-name-error";
+  const initial = creatorName.trim().charAt(0).toUpperCase() || "?";
 
   function handleContinue() {
     const trimmed = displayName.trim();
@@ -42,142 +39,80 @@ export function HookScreen({
   }
 
   return (
-    <div className="relative flex min-h-dvh flex-col overflow-hidden bg-bg px-6 pb-10 pt-8">
-      <div
-        className="pointer-events-none absolute -right-20 top-16 h-72 w-72 rounded-full opacity-20 blur-3xl"
-        style={{ background: "var(--color-primary)" }}
-        aria-hidden="true"
-      />
-      <div
-        className="pointer-events-none absolute -left-24 bottom-40 h-80 w-80 rounded-full opacity-15 blur-3xl"
-        style={{ background: "var(--color-secondary)" }}
-        aria-hidden="true"
-      />
+    <main className="relative min-h-dvh overflow-hidden bg-[linear-gradient(180deg,_#fdf1ec_0%,_#fbe4dc_55%,_#f8d9d0_100%)] text-text">
+      <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-6 pb-10 pt-8">
+        <p className="text-caption font-semibold uppercase tracking-[0.28em] text-text">
+          Dateflow
+        </p>
 
-      <div className="relative z-10 mx-auto flex min-h-dvh w-full max-w-5xl flex-col">
-        <header className="flex items-center justify-between">
-          <Logo />
-          <span className="rounded-full border border-white/70 bg-white/80 px-3 py-1 text-caption font-medium text-text-secondary shadow-sm backdrop-blur">
-            3-step invite
-          </span>
-        </header>
-
-        <div className="flex flex-1 flex-col justify-center lg:grid lg:grid-cols-[1.1fr_0.9fr] lg:gap-10">
-          <section className="max-w-2xl">
-            <h1 className="text-[clamp(3.25rem,10vw,6rem)] font-semibold leading-[0.92] tracking-[-0.06em] text-text">
-              <span className="text-primary">{creatorName}</span> wants to plan your first date.
-            </h1>
-            <p className="mt-5 max-w-xl text-body text-text-secondary">
-              This stays lightweight on purpose. Three quick choices, no account wall, and then Dateflow builds the shortlist for both of you.
+        <div className="mt-8 flex items-center gap-4 rounded-[1.5rem] bg-[#fbd7cc] p-4 shadow-[0_20px_40px_rgba(200,80,70,0.12)]">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary text-lg font-bold text-white">
+            {initial}
+          </div>
+          <div>
+            <p className="text-caption font-bold uppercase tracking-[0.14em] text-primary">
+              You&apos;re invited
             </p>
-
-            <div className="mt-8 w-full max-w-sm space-y-3">
-              <div className="space-y-2">
-                <label
-                  htmlFor="invitee-display-name"
-                  className="text-caption font-semibold uppercase tracking-[0.18em] text-secondary"
-                >
-                  Your name
-                </label>
-                <input
-                  id="invitee-display-name"
-                  name="invitee-display-name"
-                  type="text"
-                  autoComplete="given-name"
-                  aria-invalid={showError}
-                  aria-describedby={showError ? errorId : undefined}
-                  value={displayName}
-                  onChange={(event) => {
-                    setDisplayName(event.target.value);
-                    if (showError) {
-                      setShowError(false);
-                    }
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      event.preventDefault();
-                      handleContinue();
-                    }
-                  }}
-                  placeholder="What should Dateflow call you?"
-                  className="w-full rounded-[1.2rem] border border-muted bg-white/90 px-4 py-3 text-body text-text shadow-sm outline-none transition focus:border-secondary focus:ring-2 focus:ring-secondary/20"
-                />
-                {showError ? (
-                  <p id={errorId} className="text-caption text-error">
-                    Add your name so the shared result feels like both of you.
-                  </p>
-                ) : null}
-              </div>
-
-              <Button onClick={handleContinue}>Start in 60 seconds</Button>
-            </div>
-
-            <p className="mt-4 flex items-center gap-1.5 text-caption text-text-secondary">
-              <LockIcon />
-              No sign-up required
+            <p className="mt-1 text-body font-semibold leading-tight text-text">
+              {creatorName} invited you to pick the vibe
             </p>
-          </section>
+          </div>
+        </div>
 
-          <aside className="mt-10 rounded-[2rem] border border-white/70 bg-white/85 p-6 shadow-[0_24px_80px_rgba(45,42,38,0.12)] backdrop-blur-sm lg:mt-0">
-            <div className="space-y-5">
-              <TrustItem
-                eyebrow="Step 1"
-                title="Share your area"
-                body="Use location once or type a city. We only need enough to find a fair midpoint."
-              />
-              <TrustItem
-                eyebrow="Step 2"
-                title="Pick the vibe"
-                body="Food, drinks, an activity, or an event. Choose what feels easy."
-              />
-              <TrustItem
-                eyebrow="Step 3"
-                title="Let the shortlist build"
-                body="Once both sides are in, the swipe deck is prepared automatically."
-              />
-            </div>
-          </aside>
+        <h1 className="mt-10 text-[clamp(2.4rem,8vw,3.2rem)] font-bold leading-[0.98] tracking-[-0.03em] text-text">
+          Let&apos;s find what works for both of you
+        </h1>
+        <p className="mt-5 text-body text-text-secondary">
+          Add your preferences and Dateflow will find where you both align.
+        </p>
+
+        <div className="mt-8 space-y-3">
+          <label
+            htmlFor="invitee-display-name"
+            className="block text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary"
+          >
+            Your name
+          </label>
+          <input
+            id="invitee-display-name"
+            name="invitee-display-name"
+            type="text"
+            autoComplete="given-name"
+            aria-invalid={showError}
+            aria-describedby={showError ? errorId : undefined}
+            value={displayName}
+            onChange={(event) => {
+              setDisplayName(event.target.value);
+              if (showError) {
+                setShowError(false);
+              }
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                handleContinue();
+              }
+            }}
+            placeholder="What should Dateflow call you?"
+            className="h-14 w-full rounded-2xl border border-white/80 bg-white/80 px-4 text-body text-text shadow-sm outline-none transition placeholder:text-text-secondary/55 focus:border-primary focus:ring-2 focus:ring-primary/20"
+          />
+          {showError ? (
+            <p id={errorId} className="text-caption text-error">
+              Add your name so the shared result feels like both of you.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="mt-auto pt-10">
+          <Button onClick={handleContinue}>Join this date plan</Button>
+
+          <div className="mt-6 flex items-center justify-center gap-2">
+            <span className="h-1.5 w-8 rounded-full bg-primary" aria-hidden />
+            <span className="h-1.5 w-6 rounded-full bg-text/15" aria-hidden />
+            <span className="h-1.5 w-6 rounded-full bg-text/15" aria-hidden />
+          </div>
         </div>
       </div>
-    </div>
-  );
-}
-
-function TrustItem({
-  eyebrow,
-  title,
-  body,
-}: {
-  readonly eyebrow: string;
-  readonly title: string;
-  readonly body: string;
-}) {
-  return (
-    <div className="rounded-[1.5rem] border border-muted bg-bg/75 p-4">
-      <p className="text-caption font-semibold uppercase tracking-[0.2em] text-secondary">
-        {eyebrow}
-      </p>
-      <h2 className="mt-2 text-h2 font-semibold text-text">{title}</h2>
-      <p className="mt-2 text-body text-text-secondary">{body}</p>
-    </div>
-  );
-}
-
-/** Minimal lock icon — trust signal below the CTA */
-function LockIcon() {
-  return (
-    <svg
-      className="h-3.5 w-3.5"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-      <path d="M7 11V7a5 5 0 0110 0v4" />
-    </svg>
+    </main>
   );
 }

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -23,17 +23,18 @@ const CATEGORIES: { value: Category; label: string }[] = [
   { value: "EVENT", label: "Event" },
 ];
 
-const BUDGETS: { value: BudgetLevel; label: string; emoji: string }[] = [
-  { value: "BUDGET", label: "Casual", emoji: "☕" },
-  { value: "MODERATE", label: "Mid-range", emoji: "🍽️" },
-  { value: "UPSCALE", label: "Upscale", emoji: "✨" },
+const BUDGETS: { value: BudgetLevel; label: string }[] = [
+  { value: "BUDGET", label: "Casual" },
+  { value: "MODERATE", label: "Mid" },
+  { value: "UPSCALE", label: "Upscale" },
 ];
 
 /**
  * Person B landing — single-page invitation flow.
  *
- * Collects display name, area, categories, and budget in one warm peach canvas,
- * then hands off to the loading screen in plan-flow.
+ * Mirrors the Person A form pattern (translucent card on a rich gradient)
+ * but in a saturated pink palette. Collects name, area, formats, and
+ * budget before handing off to the loading screen.
  */
 export function HookScreen({
   creatorName,
@@ -46,15 +47,14 @@ export function HookScreen({
   const [location, setLocation] = useState<Location | null>(initialLocation);
   const [gpsState, setGpsState] = useState<"idle" | "loading">("idle");
   const [categories, setCategories] = useState<Category[]>([]);
-  const [budget, setBudget] = useState<BudgetLevel | null>(null);
+  const [budget, setBudget] = useState<BudgetLevel>("MODERATE");
   const [error, setError] = useState<string | null>(null);
   const initial = creatorName.trim().charAt(0).toUpperCase() || "?";
 
   const canSubmit =
     displayName.trim().length > 0 &&
     (location !== null || locationLabel.trim().length > 0) &&
-    categories.length > 0 &&
-    budget !== null;
+    categories.length > 0;
 
   function toggleCategory(category: Category) {
     setCategories((current) =>
@@ -62,6 +62,11 @@ export function HookScreen({
         ? current.filter((item) => item !== category)
         : [...current, category],
     );
+  }
+
+  function handleSurpriseMe() {
+    setCategories(CATEGORIES.map((c) => c.value));
+    setBudget("MODERATE");
   }
 
   function handleUseLocation() {
@@ -90,8 +95,8 @@ export function HookScreen({
   }
 
   function handleContinue() {
-    if (!canSubmit || !budget) {
-      setError("Fill in your name, area, at least one format, and a budget.");
+    if (!canSubmit) {
+      setError("Fill in your name, area, and at least one format.");
       return;
     }
 
@@ -109,138 +114,141 @@ export function HookScreen({
   }
 
   return (
-    <main className="relative min-h-dvh overflow-hidden bg-[linear-gradient(180deg,_#fdf1ec_0%,_#fbe4dc_55%,_#f8d9d0_100%)] text-text">
+    <main className="relative min-h-dvh overflow-hidden bg-[radial-gradient(circle_at_top,_#a83358_0%,_#6a1a36_55%,_#3d0e1f_100%)] text-white">
       <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-6 pb-10 pt-8">
-        <p className="text-center text-caption font-semibold uppercase tracking-[0.28em] text-text">
+        <p className="text-caption font-semibold uppercase tracking-[0.28em] text-white">
           Dateflow
         </p>
 
-        <div className="mt-8 flex items-center gap-4 rounded-[1.5rem] bg-[#fbd7cc] p-4 shadow-[0_20px_40px_rgba(200,80,70,0.12)]">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary text-lg font-bold text-white">
+        <div className="mt-8 flex items-center gap-4 rounded-[1.5rem] border border-white/15 bg-white/[0.08] p-4 shadow-[0_20px_40px_rgba(0,0,0,0.25)] backdrop-blur-sm">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white/90 text-lg font-bold text-[#6a1a36]">
             {initial}
           </div>
           <div>
-            <p className="text-caption font-bold uppercase tracking-[0.14em] text-primary">
+            <p className="text-caption font-bold uppercase tracking-[0.14em] text-white/80">
               You&apos;re invited
             </p>
-            <p className="mt-1 text-body font-semibold leading-tight text-text">
+            <p className="mt-1 text-body font-semibold leading-tight text-white">
               {creatorName} invited you to pick the vibe
             </p>
           </div>
         </div>
 
-        <h1 className="mt-10 text-[clamp(2.4rem,8vw,3.2rem)] font-bold leading-[0.98] tracking-[-0.03em] text-text">
+        <h1 className="mt-10 text-[clamp(2.4rem,8vw,3.2rem)] font-bold leading-[0.98] tracking-[-0.03em] text-white">
           Let&apos;s find what works for both of you
         </h1>
-        <p className="mt-5 text-body text-text-secondary">
+        <p className="mt-5 text-body text-white/65">
           Add your preferences and Dateflow will find where you both align.
         </p>
 
-        <div className="mt-8 space-y-6">
-          <div className="space-y-2">
-            <label
-              htmlFor="invitee-display-name"
-              className="block text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary"
-            >
-              Your name
-            </label>
-            <input
-              id="invitee-display-name"
-              type="text"
-              autoComplete="given-name"
-              value={displayName}
-              onChange={(event) => setDisplayName(event.target.value)}
-              placeholder="What should Dateflow call you?"
-              className="h-14 w-full rounded-2xl border border-white/80 bg-white/80 px-4 text-body text-text shadow-sm outline-none transition placeholder:text-text-secondary/55 focus:border-primary focus:ring-2 focus:ring-primary/20"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
+        <div className="mt-8 rounded-[1.75rem] border border-white/10 bg-white/[0.06] p-5 shadow-[0_24px_60px_rgba(0,0,0,0.3)] backdrop-blur-sm">
+          <div className="space-y-5">
+            <div>
               <label
-                htmlFor="invitee-location"
-                className="block text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary"
+                htmlFor="invitee-display-name"
+                className="block text-body font-semibold text-white"
               >
-                Your area
+                Your Name
               </label>
-              <button
-                type="button"
-                onClick={handleUseLocation}
-                className="cursor-pointer text-caption font-semibold text-primary transition-colors hover:text-primary-hover"
-              >
-                {gpsState === "loading" ? "Finding you..." : "Use my location"}
-              </button>
+              <input
+                id="invitee-display-name"
+                type="text"
+                autoComplete="given-name"
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+                placeholder="Alex"
+                className="mt-3 h-12 w-full rounded-xl border border-white/15 bg-transparent px-4 text-body text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+              />
             </div>
-            <input
-              id="invitee-location"
-              type="text"
-              value={locationLabel}
-              onChange={(event) => {
-                setLocation(null);
-                setLocationLabel(event.target.value);
-              }}
-              placeholder="Brooklyn or 11211"
-              className="h-14 w-full rounded-2xl border border-white/80 bg-white/80 px-4 text-body text-text shadow-sm outline-none transition placeholder:text-text-secondary/55 focus:border-primary focus:ring-2 focus:ring-primary/20"
-            />
-          </div>
 
-          <div>
-            <p className="text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
-              What sounds good?
-            </p>
-            <div className="mt-3 grid grid-cols-2 gap-3">
-              {CATEGORIES.map((category) => {
-                const selected = categories.includes(category.value);
-                return (
-                  <button
-                    key={category.value}
-                    type="button"
-                    onClick={() => toggleCategory(category.value)}
-                    className={`h-16 rounded-2xl border text-body font-semibold shadow-sm transition-all duration-200 active:scale-[0.97] ${
-                      selected
-                        ? "border-primary bg-primary text-white"
-                        : "border-white/80 bg-white/80 text-text hover:border-primary/40"
-                    }`}
-                  >
-                    {category.label}
-                  </button>
-                );
-              })}
+            <div>
+              <div className="flex items-center justify-between gap-3">
+                <label
+                  htmlFor="invitee-location"
+                  className="block text-body font-semibold text-white"
+                >
+                  Location
+                </label>
+                <button
+                  type="button"
+                  onClick={handleUseLocation}
+                  className="cursor-pointer text-caption font-semibold text-white/80 transition-colors hover:text-white"
+                >
+                  {gpsState === "loading" ? "Finding you..." : "Use my location"}
+                </button>
+              </div>
+              <input
+                id="invitee-location"
+                type="text"
+                value={locationLabel}
+                onChange={(event) => {
+                  setLocation(null);
+                  setLocationLabel(event.target.value);
+                }}
+                placeholder="Brooklyn or 11211"
+                className="mt-3 h-12 w-full rounded-xl border border-white/15 bg-transparent px-4 text-body text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+              />
             </div>
-          </div>
 
-          <div>
-            <p className="text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
-              Budget preference
-            </p>
-            <div className="mt-3 space-y-3">
-              {BUDGETS.map((option) => {
-                const selected = budget === option.value;
-                return (
-                  <button
-                    key={option.value}
-                    type="button"
-                    onClick={() => setBudget(option.value)}
-                    className={`flex h-14 w-full items-center gap-3 rounded-2xl border px-5 text-body font-semibold shadow-sm transition-all duration-200 active:scale-[0.99] ${
-                      selected
-                        ? "border-primary bg-white text-text ring-2 ring-primary/30"
-                        : "border-white/80 bg-white/80 text-text hover:border-primary/40"
-                    }`}
-                  >
-                    <span aria-hidden className="text-lg">
-                      {option.emoji}
-                    </span>
-                    <span>{option.label}</span>
-                  </button>
-                );
-              })}
+            <div>
+              <p className="text-body font-semibold text-white">Categories</p>
+              <div className="mt-3 grid grid-cols-2 gap-3">
+                {CATEGORIES.map((category) => {
+                  const selected = categories.includes(category.value);
+                  return (
+                    <button
+                      key={category.value}
+                      type="button"
+                      onClick={() => toggleCategory(category.value)}
+                      className={`h-14 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
+                        selected
+                          ? "border-white/60 bg-white/15 text-white"
+                          : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
+                      }`}
+                    >
+                      {category.label}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-          </div>
 
-          {error ? <p className="text-caption text-error">{error}</p> : null}
+            <div>
+              <p className="text-body font-semibold text-white">Budget</p>
+              <div className="mt-3 grid grid-cols-3 gap-3">
+                {BUDGETS.map((option) => {
+                  const selected = budget === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setBudget(option.value)}
+                      className={`h-12 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
+                        selected
+                          ? "border-white/60 bg-white/15 text-white"
+                          : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleSurpriseMe}
+              className="flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/[0.04] text-body font-semibold text-white transition-colors hover:bg-white/10"
+            >
+              <span aria-hidden>✨</span> Surprise me
+            </button>
+          </div>
         </div>
 
-        <div className="mt-auto pt-10">
+        {error ? <p className="mt-4 text-body text-error">{error}</p> : null}
+
+        <div className="mt-6">
           <Button onClick={handleContinue} disabled={!canSubmit}>
             Join this date plan
           </Button>

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { BudgetIcon } from "./budget-icon";
+import { Button } from "./button";
 import { CategoryIcon } from "./category-icon";
 import type { BudgetLevel, Category, Location } from "../lib/types/preference";
 
@@ -244,24 +245,9 @@ export function HookScreen({
         {error ? <p className="mt-4 text-body text-error">{error}</p> : null}
 
         <div className="mt-6">
-          <button
-            type="button"
-            onClick={handleContinue}
-            disabled={!canSubmit}
-            className={`group relative flex h-16 w-full items-center justify-center gap-2 overflow-hidden rounded-2xl text-[1.05rem] font-bold tracking-tight text-white transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80 ${
-              canSubmit
-                ? "cursor-pointer bg-[linear-gradient(135deg,_#ff8fa3_0%,_#ff5a86_45%,_#ff3d7f_100%)] shadow-[0_20px_40px_rgba(255,61,127,0.45),_0_0_0_1px_rgba(255,255,255,0.25)_inset] motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-[0_26px_50px_rgba(255,61,127,0.55),_0_0_0_1px_rgba(255,255,255,0.35)_inset] active:translate-y-0"
-                : "cursor-not-allowed bg-white/10 text-white/50 shadow-none"
-            }`}
-          >
-            <span className="relative z-10">Join this date plan</span>
-            {canSubmit ? (
-              <span
-                aria-hidden
-                className="pointer-events-none absolute inset-x-2 top-1 h-1/3 rounded-t-xl bg-white/25 blur-[2px]"
-              />
-            ) : null}
-          </button>
+          <Button variant="secondary" onClick={handleContinue} disabled={!canSubmit}>
+            Join this date plan
+          </Button>
         </div>
       </div>
     </main>

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -29,14 +29,10 @@ const BUDGETS: { value: BudgetLevel; label: string }[] = [
   { value: "UPSCALE", label: "Upscale" },
 ];
 
-const INK = "#3d0e1f";
-
 /**
  * Person B landing — single-page invitation flow.
  *
- * Petal pastel gradient with dark-ink type. Mirrors the Person A form
- * pattern: translucent card with Name, Location, Categories, Budget, and
- * Surprise me, then hands off to the loading screen.
+ * Magenta rose gradient mirroring the Person A form pattern.
  */
 export function HookScreen({
   creatorName,
@@ -116,43 +112,37 @@ export function HookScreen({
   }
 
   return (
-    <main
-      className="relative min-h-dvh overflow-hidden bg-[radial-gradient(circle_at_top,_#f8cbd3_0%,_#e8a5b4_55%,_#c47a8e_100%)]"
-      style={{ color: INK }}
-    >
+    <main className="relative min-h-dvh overflow-hidden bg-[radial-gradient(circle_at_top,_#c23a7a_0%,_#7a1e4c_55%,_#3e0f26_100%)] text-white">
       <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-6 pb-10 pt-8">
-        <p className="text-caption font-semibold uppercase tracking-[0.28em]">
+        <p className="text-caption font-semibold uppercase tracking-[0.28em] text-white">
           Dateflow
         </p>
 
-        <div className="mt-8 flex items-center gap-4 rounded-[1.5rem] border border-[#3d0e1f]/10 bg-white/50 p-4 shadow-[0_20px_40px_rgba(61,14,31,0.12)] backdrop-blur-sm">
-          <div
-            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-lg font-bold text-white"
-            style={{ background: INK }}
-          >
+        <div className="mt-8 flex items-center gap-4 rounded-[1.5rem] border border-white/15 bg-white/[0.08] p-4 shadow-[0_20px_40px_rgba(0,0,0,0.25)] backdrop-blur-sm">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white/90 text-lg font-bold text-[#7a1e4c]">
             {initial}
           </div>
           <div>
-            <p className="text-caption font-bold uppercase tracking-[0.14em] opacity-70">
+            <p className="text-caption font-bold uppercase tracking-[0.14em] text-white/80">
               You&apos;re invited
             </p>
-            <p className="mt-1 text-body font-semibold leading-tight">
+            <p className="mt-1 text-body font-semibold leading-tight text-white">
               {creatorName} invited you to pick the vibe
             </p>
           </div>
         </div>
 
-        <h1 className="mt-10 text-[clamp(2.4rem,8vw,3.2rem)] font-bold leading-[0.98] tracking-[-0.03em]">
+        <h1 className="mt-10 text-[clamp(2.4rem,8vw,3.2rem)] font-bold leading-[0.98] tracking-[-0.03em] text-white">
           Let&apos;s find what works for both of you
         </h1>
-        <p className="mt-5 text-body opacity-70">
+        <p className="mt-5 text-body text-white/65">
           Add your preferences and Dateflow will find where you both align.
         </p>
 
-        <div className="mt-8 rounded-[1.75rem] border border-[#3d0e1f]/10 bg-white/45 p-5 shadow-[0_24px_60px_rgba(61,14,31,0.12)] backdrop-blur-sm">
+        <div className="mt-8 rounded-[1.75rem] border border-white/10 bg-white/[0.06] p-5 shadow-[0_24px_60px_rgba(0,0,0,0.3)] backdrop-blur-sm">
           <div className="space-y-5">
             <div>
-              <label htmlFor="invitee-display-name" className="block text-body font-semibold">
+              <label htmlFor="invitee-display-name" className="block text-body font-semibold text-white">
                 Your Name
               </label>
               <input
@@ -162,20 +152,19 @@ export function HookScreen({
                 value={displayName}
                 onChange={(event) => setDisplayName(event.target.value)}
                 placeholder="Alex"
-                className="mt-3 h-12 w-full rounded-xl border border-[#3d0e1f]/15 bg-white/60 px-4 text-body placeholder:text-[#3d0e1f]/40 focus:border-[#3d0e1f]/50 focus:outline-none"
-                style={{ color: INK }}
+                className="mt-3 h-12 w-full rounded-xl border border-white/15 bg-transparent px-4 text-body text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
               />
             </div>
 
             <div>
               <div className="flex items-center justify-between gap-3">
-                <label htmlFor="invitee-location" className="block text-body font-semibold">
+                <label htmlFor="invitee-location" className="block text-body font-semibold text-white">
                   Location
                 </label>
                 <button
                   type="button"
                   onClick={handleUseLocation}
-                  className="cursor-pointer text-caption font-semibold opacity-70 transition-opacity hover:opacity-100"
+                  className="cursor-pointer text-caption font-semibold text-white/80 transition-colors hover:text-white"
                 >
                   {gpsState === "loading" ? "Finding you..." : "Use my location"}
                 </button>
@@ -189,13 +178,12 @@ export function HookScreen({
                   setLocationLabel(event.target.value);
                 }}
                 placeholder="Brooklyn or 11211"
-                className="mt-3 h-12 w-full rounded-xl border border-[#3d0e1f]/15 bg-white/60 px-4 text-body placeholder:text-[#3d0e1f]/40 focus:border-[#3d0e1f]/50 focus:outline-none"
-                style={{ color: INK }}
+                className="mt-3 h-12 w-full rounded-xl border border-white/15 bg-transparent px-4 text-body text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
               />
             </div>
 
             <div>
-              <p className="text-body font-semibold">Categories</p>
+              <p className="text-body font-semibold text-white">Categories</p>
               <div className="mt-3 grid grid-cols-2 gap-3">
                 {CATEGORIES.map((category) => {
                   const selected = categories.includes(category.value);
@@ -206,10 +194,9 @@ export function HookScreen({
                       onClick={() => toggleCategory(category.value)}
                       className={`h-14 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
-                          ? "border-[#3d0e1f]/60 bg-[#3d0e1f]/10"
-                          : "border-[#3d0e1f]/15 bg-white/55 hover:border-[#3d0e1f]/35"
+                          ? "border-white/60 bg-white/15 text-white"
+                          : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
                       }`}
-                      style={{ color: INK }}
                     >
                       {category.label}
                     </button>
@@ -219,7 +206,7 @@ export function HookScreen({
             </div>
 
             <div>
-              <p className="text-body font-semibold">Budget</p>
+              <p className="text-body font-semibold text-white">Budget</p>
               <div className="mt-3 grid grid-cols-3 gap-3">
                 {BUDGETS.map((option) => {
                   const selected = budget === option.value;
@@ -230,10 +217,9 @@ export function HookScreen({
                       onClick={() => setBudget(option.value)}
                       className={`h-12 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
-                          ? "border-[#3d0e1f]/60 bg-[#3d0e1f]/10"
-                          : "border-[#3d0e1f]/15 bg-white/55 hover:border-[#3d0e1f]/35"
+                          ? "border-white/60 bg-white/15 text-white"
+                          : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
                       }`}
-                      style={{ color: INK }}
                     >
                       {option.label}
                     </button>
@@ -245,8 +231,7 @@ export function HookScreen({
             <button
               type="button"
               onClick={handleSurpriseMe}
-              className="flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-[#3d0e1f]/20 bg-white/55 text-body font-semibold transition-colors hover:bg-white/70"
-              style={{ color: INK }}
+              className="flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/[0.04] text-body font-semibold text-white transition-colors hover:bg-white/10"
             >
               <span aria-hidden>✨</span> Surprise me
             </button>

--- a/web-service/src/components/hook-screen.tsx
+++ b/web-service/src/components/hook-screen.tsx
@@ -2,20 +2,38 @@
 
 import { useState } from "react";
 import { Button } from "./button";
-import type { Location } from "../lib/types/preference";
+import type { BudgetLevel, Category, Location } from "../lib/types/preference";
 
 type HookScreenProps = {
   readonly creatorName: string;
   readonly initialDisplayName?: string;
   readonly initialLocation?: Location | null;
-  readonly onContinue: (displayName: string, location: Location) => void;
+  readonly onContinue: (data: {
+    displayName: string;
+    location: Location;
+    categories: Category[];
+    budget: BudgetLevel;
+  }) => void;
 };
 
+const CATEGORIES: { value: Category; label: string }[] = [
+  { value: "RESTAURANT", label: "Food" },
+  { value: "BAR", label: "Drinks" },
+  { value: "ACTIVITY", label: "Activity" },
+  { value: "EVENT", label: "Event" },
+];
+
+const BUDGETS: { value: BudgetLevel; label: string; emoji: string }[] = [
+  { value: "BUDGET", label: "Casual", emoji: "☕" },
+  { value: "MODERATE", label: "Mid-range", emoji: "🍽️" },
+  { value: "UPSCALE", label: "Upscale", emoji: "✨" },
+];
+
 /**
- * Person B landing — the invitation hook.
+ * Person B landing — single-page invitation flow.
  *
- * Warm peach canvas. Collects display name and location (GPS or typed)
- * before handing off to the vibe screen.
+ * Collects display name, area, categories, and budget in one warm peach canvas,
+ * then hands off to the loading screen in plan-flow.
  */
 export function HookScreen({
   creatorName,
@@ -27,10 +45,24 @@ export function HookScreen({
   const [locationLabel, setLocationLabel] = useState(initialLocation?.label ?? "");
   const [location, setLocation] = useState<Location | null>(initialLocation);
   const [gpsState, setGpsState] = useState<"idle" | "loading">("idle");
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [budget, setBudget] = useState<BudgetLevel | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [showNameError, setShowNameError] = useState(false);
-  const nameErrorId = "invitee-display-name-error";
   const initial = creatorName.trim().charAt(0).toUpperCase() || "?";
+
+  const canSubmit =
+    displayName.trim().length > 0 &&
+    (location !== null || locationLabel.trim().length > 0) &&
+    categories.length > 0 &&
+    budget !== null;
+
+  function toggleCategory(category: Category) {
+    setCategories((current) =>
+      current.includes(category)
+        ? current.filter((item) => item !== category)
+        : [...current, category],
+    );
+  }
 
   function handleUseLocation() {
     if (!navigator.geolocation) {
@@ -58,31 +90,28 @@ export function HookScreen({
   }
 
   function handleContinue() {
-    const trimmed = displayName.trim();
+    if (!canSubmit || !budget) {
+      setError("Fill in your name, area, at least one format, and a budget.");
+      return;
+    }
+
     const trimmedLocation = locationLabel.trim();
-
-    if (!trimmed) {
-      setShowNameError(true);
-      return;
-    }
-
-    if (!location && trimmedLocation.length === 0) {
-      setError("Add your area so we can find a fair midpoint.");
-      return;
-    }
-
     const resolvedLocation: Location =
       location ?? { lat: 0, lng: 0, label: trimmedLocation };
 
-    setShowNameError(false);
     setError(null);
-    onContinue(trimmed, resolvedLocation);
+    onContinue({
+      displayName: displayName.trim(),
+      location: resolvedLocation,
+      categories,
+      budget,
+    });
   }
 
   return (
     <main className="relative min-h-dvh overflow-hidden bg-[linear-gradient(180deg,_#fdf1ec_0%,_#fbe4dc_55%,_#f8d9d0_100%)] text-text">
       <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-6 pb-10 pt-8">
-        <p className="text-caption font-semibold uppercase tracking-[0.28em] text-text">
+        <p className="text-center text-caption font-semibold uppercase tracking-[0.28em] text-text">
           Dateflow
         </p>
 
@@ -107,7 +136,7 @@ export function HookScreen({
           Add your preferences and Dateflow will find where you both align.
         </p>
 
-        <div className="mt-8 space-y-5">
+        <div className="mt-8 space-y-6">
           <div className="space-y-2">
             <label
               htmlFor="invitee-display-name"
@@ -117,26 +146,13 @@ export function HookScreen({
             </label>
             <input
               id="invitee-display-name"
-              name="invitee-display-name"
               type="text"
               autoComplete="given-name"
-              aria-invalid={showNameError}
-              aria-describedby={showNameError ? nameErrorId : undefined}
               value={displayName}
-              onChange={(event) => {
-                setDisplayName(event.target.value);
-                if (showNameError) {
-                  setShowNameError(false);
-                }
-              }}
+              onChange={(event) => setDisplayName(event.target.value)}
               placeholder="What should Dateflow call you?"
               className="h-14 w-full rounded-2xl border border-white/80 bg-white/80 px-4 text-body text-text shadow-sm outline-none transition placeholder:text-text-secondary/55 focus:border-primary focus:ring-2 focus:ring-primary/20"
             />
-            {showNameError ? (
-              <p id={nameErrorId} className="text-caption text-error">
-                Add your name so the shared result feels like both of you.
-              </p>
-            ) : null}
           </div>
 
           <div className="space-y-2">
@@ -163,28 +179,71 @@ export function HookScreen({
                 setLocation(null);
                 setLocationLabel(event.target.value);
               }}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  handleContinue();
-                }
-              }}
               placeholder="Brooklyn or 11211"
               className="h-14 w-full rounded-2xl border border-white/80 bg-white/80 px-4 text-body text-text shadow-sm outline-none transition placeholder:text-text-secondary/55 focus:border-primary focus:ring-2 focus:ring-primary/20"
             />
+          </div>
+
+          <div>
+            <p className="text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
+              What sounds good?
+            </p>
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              {CATEGORIES.map((category) => {
+                const selected = categories.includes(category.value);
+                return (
+                  <button
+                    key={category.value}
+                    type="button"
+                    onClick={() => toggleCategory(category.value)}
+                    className={`h-16 rounded-2xl border text-body font-semibold shadow-sm transition-all duration-200 active:scale-[0.97] ${
+                      selected
+                        ? "border-primary bg-primary text-white"
+                        : "border-white/80 bg-white/80 text-text hover:border-primary/40"
+                    }`}
+                  >
+                    {category.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
+              Budget preference
+            </p>
+            <div className="mt-3 space-y-3">
+              {BUDGETS.map((option) => {
+                const selected = budget === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setBudget(option.value)}
+                    className={`flex h-14 w-full items-center gap-3 rounded-2xl border px-5 text-body font-semibold shadow-sm transition-all duration-200 active:scale-[0.99] ${
+                      selected
+                        ? "border-primary bg-white text-text ring-2 ring-primary/30"
+                        : "border-white/80 bg-white/80 text-text hover:border-primary/40"
+                    }`}
+                  >
+                    <span aria-hidden className="text-lg">
+                      {option.emoji}
+                    </span>
+                    <span>{option.label}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
           {error ? <p className="text-caption text-error">{error}</p> : null}
         </div>
 
         <div className="mt-auto pt-10">
-          <Button onClick={handleContinue}>Join this date plan</Button>
-
-          <div className="mt-6 flex items-center justify-center gap-2">
-            <span className="h-1.5 w-8 rounded-full bg-primary" aria-hidden />
-            <span className="h-1.5 w-6 rounded-full bg-text/15" aria-hidden />
-            <span className="h-1.5 w-6 rounded-full bg-text/15" aria-hidden />
-          </div>
+          <Button onClick={handleContinue} disabled={!canSubmit}>
+            Join this date plan
+          </Button>
         </div>
       </div>
     </main>

--- a/web-service/src/components/person-a-flow.tsx
+++ b/web-service/src/components/person-a-flow.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "./button";
-import { CategoryIcon } from "./category-icon";
-import { Logo } from "./logo";
 import { createSessionStatusSync } from "../lib/session-status-sync";
 import type { BudgetLevel, Category, Location } from "../lib/types/preference";
 
@@ -36,10 +34,10 @@ const CATEGORIES: { value: Category; label: string }[] = [
   { value: "EVENT", label: "Event" },
 ];
 
-const BUDGETS: { value: BudgetLevel; label: string; symbol: string }[] = [
-  { value: "BUDGET", label: "Casual", symbol: "$" },
-  { value: "MODERATE", label: "Mid-range", symbol: "$$" },
-  { value: "UPSCALE", label: "Upscale", symbol: "$$$" },
+const BUDGETS: { value: BudgetLevel; label: string }[] = [
+  { value: "BUDGET", label: "Casual" },
+  { value: "MODERATE", label: "Mid" },
+  { value: "UPSCALE", label: "Upscale" },
 ];
 
 export function PersonAFlow() {
@@ -47,7 +45,6 @@ export function PersonAFlow() {
   const [name, setName] = useState("");
   const [locationLabel, setLocationLabel] = useState("");
   const [location, setLocation] = useState<Location | null>(null);
-  const [gpsState, setGpsState] = useState<"idle" | "loading">("idle");
   const [categories, setCategories] = useState<Category[]>(["RESTAURANT", "BAR"]);
   const [budget, setBudget] = useState<BudgetLevel>("MODERATE");
   const [error, setError] = useState<string | null>(null);
@@ -71,29 +68,9 @@ export function PersonAFlow() {
     );
   }
 
-  function handleUseLocation() {
-    if (!navigator.geolocation) {
-      setError("Location access is unavailable in this browser.");
-      return;
-    }
-
-    setError(null);
-    setGpsState("loading");
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        setLocation({
-          lat: position.coords.latitude,
-          lng: position.coords.longitude,
-          label: "Current Location",
-        });
-        setLocationLabel("Current Location");
-        setGpsState("idle");
-      },
-      () => {
-        setGpsState("idle");
-        setError("We couldn't access your location. Enter your city or zip instead.");
-      },
-    );
+  function handleSurpriseMe() {
+    setCategories(CATEGORIES.map((category) => category.value));
+    setBudget("MODERATE");
   }
 
   async function handleCreateSession() {
@@ -223,151 +200,14 @@ export function PersonAFlow() {
     router.push(redirectHref);
   }, [createdSession, createdSessionStatus, router]);
 
-  return (
-    <main className="relative min-h-dvh overflow-hidden bg-bg text-text">
-      <div
-        className="pointer-events-none absolute -left-16 top-10 h-72 w-72 rounded-full blur-3xl"
-        style={{ background: "var(--color-primary-muted)" }}
-        aria-hidden="true"
-      />
-      <div
-        className="pointer-events-none absolute right-0 top-24 h-80 w-80 rounded-full blur-3xl"
-        style={{ background: "var(--color-secondary-muted)" }}
-        aria-hidden="true"
-      />
-
-      <div className="mx-auto flex min-h-dvh max-w-6xl flex-col px-6 pb-12 pt-8 sm:px-8 lg:grid lg:grid-cols-[1.1fr_0.9fr] lg:gap-12 lg:pb-16">
-        <section className="relative z-10 flex flex-col justify-between">
-          <div>
-            <Logo />
-            <h1 className="mt-10 max-w-2xl text-[clamp(3.2rem,10vw,6.8rem)] font-semibold leading-[0.92] tracking-[-0.06em]">
-              Build the date invite before the vibe goes cold.
-            </h1>
-            <p className="mt-5 max-w-xl text-body text-text-secondary">
-              Start the session, set your preferences, and send one clean link.
-              For demo mode, you can open the invite yourself and run the full Person B journey.
-            </p>
-          </div>
-
-          <div className="mt-10 grid gap-4 sm:grid-cols-3">
-            <StatCard label="Time to start" value="60 sec" />
-            <StatCard label="Accounts" value="None" />
-            <StatCard label="Demo path" value="Built in" />
-          </div>
-        </section>
-
-        <section className="relative z-10 mt-10 rounded-[2rem] border border-white/70 bg-white/85 p-6 shadow-[0_24px_80px_rgba(45,42,38,0.12)] backdrop-blur-sm sm:p-7 lg:mt-0">
-          {!createdSession ? (
-            <div className="space-y-6">
-              <div>
-                <p className="text-caption font-semibold uppercase tracking-[0.24em] text-primary">
-                  Setup
-                </p>
-                <h2 className="mt-2 text-h1 font-semibold">Create your invite</h2>
-              </div>
-
-              <label className="block">
-                <span className="mb-2 block text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
-                  Your first name
-                </span>
-                <input
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  placeholder="Alex"
-                  className="h-14 w-full rounded-2xl border-[1.5px] border-muted bg-surface px-4 text-body text-text placeholder:text-text-secondary/55 focus:border-primary focus:outline-none"
-                />
-              </label>
-
-              <div className="space-y-3">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
-                    Your area
-                  </span>
-                  <button
-                    onClick={handleUseLocation}
-                    className="cursor-pointer text-caption font-semibold text-secondary transition-colors hover:text-secondary/75"
-                  >
-                    {gpsState === "loading" ? "Finding you..." : "Use my location"}
-                  </button>
-                </div>
-                <input
-                  value={locationLabel}
-                  onChange={(event) => {
-                    setLocation(null);
-                    setLocationLabel(event.target.value);
-                  }}
-                  placeholder="Brooklyn or 11211"
-                  className="h-14 w-full rounded-2xl border-[1.5px] border-muted bg-surface px-4 text-body text-text placeholder:text-text-secondary/55 focus:border-primary focus:outline-none"
-                />
-              </div>
-
-              <div>
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
-                    What sounds good?
-                  </span>
-                  <button
-                    onClick={() => setCategories(CATEGORIES.map((category) => category.value))}
-                    className="cursor-pointer text-caption font-semibold text-secondary transition-colors hover:text-secondary/75"
-                  >
-                    Surprise me
-                  </button>
-                </div>
-                <div className="mt-3 grid grid-cols-2 gap-3">
-                  {CATEGORIES.map((category) => {
-                    const selected = categories.includes(category.value);
-
-                    return (
-                      <button
-                        key={category.value}
-                        onClick={() => toggleCategory(category.value)}
-                        className={`flex h-[78px] cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border-[1.5px] transition-all duration-200 active:scale-[0.97] ${
-                          selected
-                            ? "border-primary bg-primary text-white shadow-sm"
-                            : "border-muted bg-surface text-text shadow-sm hover:border-text-secondary"
-                        }`}
-                      >
-                        <CategoryIcon category={category.value} className="h-5 w-5" />
-                        <span className="text-body font-semibold">{category.label}</span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <span className="text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
-                  Budget vibe
-                </span>
-                <div className="mt-3 grid grid-cols-3 gap-3">
-                  {BUDGETS.map((option) => {
-                    const selected = budget === option.value;
-
-                    return (
-                      <button
-                        key={option.value}
-                        onClick={() => setBudget(option.value)}
-                        className={`flex h-[68px] cursor-pointer flex-col items-center justify-center rounded-2xl border-[1.5px] transition-all duration-200 active:scale-[0.97] ${
-                          selected
-                            ? "border-secondary bg-secondary-muted text-secondary"
-                            : "border-muted bg-surface text-text shadow-sm hover:border-text-secondary"
-                        }`}
-                      >
-                        <span className="text-body font-bold">{option.symbol}</span>
-                        <span className="text-caption">{option.label}</span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {error ? <p className="text-body text-error">{error}</p> : null}
-
-              <Button onClick={handleCreateSession} disabled={!canSubmit} loading={submitting}>
-                Create invite link
-              </Button>
-            </div>
-          ) : (
+  if (createdSession) {
+    return (
+      <main className="relative min-h-dvh overflow-hidden bg-[radial-gradient(circle_at_top,_#4a302a_0%,_#2a1a15_60%,_#1a0f0c_100%)] px-6 pb-12 pt-8 text-white">
+        <div className="mx-auto w-full max-w-md">
+          <p className="text-caption font-semibold uppercase tracking-[0.24em] text-white/70">
+            Dateflow
+          </p>
+          <div className="mt-10 rounded-[2rem] border border-white/10 bg-white/5 p-6 shadow-[0_24px_80px_rgba(0,0,0,0.35)] backdrop-blur-sm">
             <InviteReadyState
               sessionId={createdSession.id}
               shareUrl={createdSession.shareUrl}
@@ -376,8 +216,130 @@ export function PersonAFlow() {
               errorMessage={error}
               onCopyInvite={handleCopyInvite}
             />
-          )}
-        </section>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="relative min-h-dvh overflow-hidden bg-[radial-gradient(circle_at_top,_#4a302a_0%,_#2a1a15_60%,_#1a0f0c_100%)] text-white">
+      <div className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-6 pb-10 pt-8">
+        <p className="text-caption font-semibold uppercase tracking-[0.28em] text-white">
+          Dateflow
+        </p>
+
+        <h1 className="mt-10 text-[clamp(2.6rem,8.5vw,3.4rem)] font-bold leading-[0.98] tracking-[-0.03em] text-white">
+          Build the date invite before the vibe goes cold
+        </h1>
+        <p className="mt-5 text-body text-white/65">
+          Start the session, set your preferences, and send one clean link.
+        </p>
+
+        <div className="mt-8 rounded-[1.75rem] border border-white/10 bg-white/[0.06] p-5 shadow-[0_24px_60px_rgba(0,0,0,0.3)] backdrop-blur-sm">
+          <div className="space-y-5">
+            <div>
+              <label
+                htmlFor="person-a-name"
+                className="block text-body font-semibold text-white"
+              >
+                Your Name
+              </label>
+              <input
+                id="person-a-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Alex"
+                className="mt-3 h-12 w-full rounded-xl border border-white/15 bg-transparent px-4 text-body text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="person-a-location"
+                className="block text-body font-semibold text-white"
+              >
+                Location
+              </label>
+              <input
+                id="person-a-location"
+                value={locationLabel}
+                onChange={(event) => {
+                  setLocation(null);
+                  setLocationLabel(event.target.value);
+                }}
+                placeholder="Brooklyn or 11211"
+                className="mt-3 h-12 w-full rounded-xl border border-white/15 bg-transparent px-4 text-body text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <p className="text-body font-semibold text-white">Categories</p>
+              <div className="mt-3 grid grid-cols-2 gap-3">
+                {CATEGORIES.map((category) => {
+                  const selected = categories.includes(category.value);
+                  return (
+                    <button
+                      key={category.value}
+                      type="button"
+                      onClick={() => toggleCategory(category.value)}
+                      className={`h-14 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
+                        selected
+                          ? "border-white/60 bg-white/15 text-white"
+                          : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
+                      }`}
+                    >
+                      {category.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div>
+              <p className="text-body font-semibold text-white">Budget</p>
+              <div className="mt-3 grid grid-cols-3 gap-3">
+                {BUDGETS.map((option) => {
+                  const selected = budget === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setBudget(option.value)}
+                      className={`h-12 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
+                        selected
+                          ? "border-white/60 bg-white/15 text-white"
+                          : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleSurpriseMe}
+              className="flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/[0.04] text-body font-semibold text-white transition-colors hover:bg-white/10"
+            >
+              <span aria-hidden>✨</span> Surprise me
+            </button>
+          </div>
+        </div>
+
+        {error ? <p className="mt-4 text-body text-error">{error}</p> : null}
+
+        <div className="mt-6">
+          <Button onClick={handleCreateSession} disabled={!canSubmit} loading={submitting}>
+            Create invite link
+          </Button>
+        </div>
+
+        <p className="mt-6 text-center text-caption text-white/50">
+          2,847 dates planned this week
+        </p>
       </div>
     </main>
   );
@@ -398,9 +360,7 @@ export function InviteReadyState({
         ? "Continue to your swipe deck"
         : sessionStatus === "expired"
           ? "Start a new session"
-          : sessionStatus === "generation_failed"
-            ? "Open live session"
-        : "Open live session";
+          : "Open live session";
   const liveSessionHref = sessionStatus === "expired" ? "/" : `/plan/${sessionId}`;
   const statusMessage =
     sessionStatus === "expired"
@@ -411,23 +371,21 @@ export function InviteReadyState({
 
   return (
     <div className="space-y-6">
-      <div className="rounded-[1.75rem] bg-[linear-gradient(140deg,#1f1a16,#57473c)] p-6 text-white shadow-[0_20px_50px_rgba(45,42,38,0.24)]">
+      <div>
         <p className="text-caption font-semibold uppercase tracking-[0.22em] text-white/70">
           Invite sent
         </p>
-        <h2 className="mt-3 text-h1 font-semibold">
+        <h2 className="mt-3 text-h1 font-semibold text-white">
           Your side is set. Now hand off the link.
         </h2>
-        <p className="mt-3 max-w-xl text-body text-white/80">
-          {statusMessage}
-        </p>
+        <p className="mt-3 text-body text-white/70">{statusMessage}</p>
       </div>
 
-      <div className="rounded-[1.5rem] border border-muted bg-bg p-4">
-        <p className="text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
+      <div className="rounded-2xl border border-white/15 bg-white/[0.04] p-4">
+        <p className="text-caption font-semibold uppercase tracking-[0.18em] text-white/60">
           Share link
         </p>
-        <p className="mt-3 break-all text-body font-medium">{shareUrl}</p>
+        <p className="mt-3 break-all text-body font-medium text-white">{shareUrl}</p>
       </div>
 
       <div className="grid gap-3">
@@ -436,7 +394,7 @@ export function InviteReadyState({
         </Button>
         <a
           href={liveSessionHref}
-          className="flex w-full items-center justify-center gap-2 rounded-2xl border-[1.5px] border-muted bg-surface text-body font-semibold text-text transition-all duration-200 hover:border-text-secondary active:scale-[0.98] h-14 cursor-pointer"
+          className="flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-2xl border border-white/20 bg-white/[0.04] text-body font-semibold text-white transition-colors hover:bg-white/10"
         >
           {liveSessionLabel}
         </a>
@@ -476,21 +434,4 @@ export function getInviteReadyRedirectHref(
   }
 
   return null;
-}
-
-function StatCard({
-  label,
-  value,
-}: {
-  readonly label: string;
-  readonly value: string;
-}) {
-  return (
-    <div className="rounded-[1.5rem] border border-white/70 bg-white/80 p-4 shadow-sm backdrop-blur">
-      <p className="text-caption font-semibold uppercase tracking-[0.18em] text-text-secondary">
-        {label}
-      </p>
-      <p className="mt-2 text-h2 font-semibold text-text">{value}</p>
-    </div>
-  );
 }

--- a/web-service/src/components/person-a-flow.tsx
+++ b/web-service/src/components/person-a-flow.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "./button";
+import { BudgetIcon } from "./budget-icon";
+import { CategoryIcon } from "./category-icon";
 import { createSessionStatusSync } from "../lib/session-status-sync";
 import type { BudgetLevel, Category, Location } from "../lib/types/preference";
 
@@ -318,12 +320,13 @@ export function PersonAFlow() {
                       key={category.value}
                       type="button"
                       onClick={() => toggleCategory(category.value)}
-                      className={`h-14 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
+                      className={`flex h-14 items-center justify-center gap-2 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
                           ? "border-white/60 bg-white/15 text-white"
                           : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
                       }`}
                     >
+                      <CategoryIcon category={category.value} className="h-5 w-5" />
                       {category.label}
                     </button>
                   );
@@ -341,12 +344,13 @@ export function PersonAFlow() {
                       key={option.value}
                       type="button"
                       onClick={() => setBudget(option.value)}
-                      className={`h-12 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
+                      className={`flex h-12 items-center justify-center gap-1.5 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
                           ? "border-white/60 bg-white/15 text-white"
                           : "border-white/15 bg-white/[0.04] text-white/85 hover:border-white/30"
                       }`}
                     >
+                      <BudgetIcon budget={option.value} className="h-4 w-4" />
                       {option.label}
                     </button>
                   );

--- a/web-service/src/components/person-a-flow.tsx
+++ b/web-service/src/components/person-a-flow.tsx
@@ -45,6 +45,7 @@ export function PersonAFlow() {
   const [name, setName] = useState("");
   const [locationLabel, setLocationLabel] = useState("");
   const [location, setLocation] = useState<Location | null>(null);
+  const [gpsState, setGpsState] = useState<"idle" | "loading">("idle");
   const [categories, setCategories] = useState<Category[]>(["RESTAURANT", "BAR"]);
   const [budget, setBudget] = useState<BudgetLevel>("MODERATE");
   const [error, setError] = useState<string | null>(null);
@@ -65,6 +66,31 @@ export function PersonAFlow() {
       current.includes(category)
         ? current.filter((item) => item !== category)
         : [...current, category],
+    );
+  }
+
+  function handleUseLocation() {
+    if (!navigator.geolocation) {
+      setError("Location access is unavailable in this browser.");
+      return;
+    }
+
+    setError(null);
+    setGpsState("loading");
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setLocation({
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+          label: "Current Location",
+        });
+        setLocationLabel("Current Location");
+        setGpsState("idle");
+      },
+      () => {
+        setGpsState("idle");
+        setError("We couldn't access your location. Enter your city or zip instead.");
+      },
     );
   }
 
@@ -255,12 +281,21 @@ export function PersonAFlow() {
             </div>
 
             <div>
-              <label
-                htmlFor="person-a-location"
-                className="block text-body font-semibold text-white"
-              >
-                Location
-              </label>
+              <div className="flex items-center justify-between gap-3">
+                <label
+                  htmlFor="person-a-location"
+                  className="block text-body font-semibold text-white"
+                >
+                  Location
+                </label>
+                <button
+                  type="button"
+                  onClick={handleUseLocation}
+                  className="cursor-pointer text-caption font-semibold text-white/80 transition-colors hover:text-white"
+                >
+                  {gpsState === "loading" ? "Finding you..." : "Use my location"}
+                </button>
+              </div>
               <input
                 id="person-a-location"
                 value={locationLabel}

--- a/web-service/src/components/person-a-flow.tsx
+++ b/web-service/src/components/person-a-flow.tsx
@@ -319,6 +319,7 @@ export function PersonAFlow() {
                     <button
                       key={category.value}
                       type="button"
+                      aria-pressed={selected}
                       onClick={() => toggleCategory(category.value)}
                       className={`flex h-14 items-center justify-center gap-2 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected
@@ -343,6 +344,7 @@ export function PersonAFlow() {
                     <button
                       key={option.value}
                       type="button"
+                      aria-pressed={selected}
                       onClick={() => setBudget(option.value)}
                       className={`flex h-12 items-center justify-center gap-1.5 rounded-xl border text-body font-semibold transition-all duration-200 active:scale-[0.97] ${
                         selected


### PR DESCRIPTION
## Summary

- Redesigned **Person A** landing as a dark brown, mobile-first single-column flow: translucent glass card with Name / Location (with "Use my location") / 2×2 Categories / 3-up Budget / Surprise me, coral "Create invite link" CTA, and "2,847 dates planned this week" footer.
- Collapsed **Person B** into a single-page landing on a **Raspberry** radial gradient (\`#d03d6a → #8a2346 → #4a1224\`): invitation banner ("{Creator} invited you to pick the vibe"), name + location (with geolocation), 2×2 Categories, 3-up Budget, Surprise me. Removed the intermediate \`HookScreen → LocationScreen → VibeScreen\` paging; preferences are submitted directly from the single page.
- Added **category icons** (Food / Drinks / Activity / Event) and a new **\`BudgetIcon\`** (cup / plate / sparkle) to both Person A and Person B chip grids.
- New hero CTA on Person B: white pill with dark raspberry text and a soft pink glow shadow.
- No changes to service logic, API routes, or the preferences payload shape.

## Follow-up

- [dateflow#103](https://github.com/Aiden-Barrera/dateflow/issues/103) tracks extending this color philosophy across the rest of the product (swipe, results, loading screen, auth sheet, history) and a design-tokens audit.

## Test plan

- [ ] Manual: open \`/\` (Person A) — verify dark-brown layout, "Use my location" requests GPS, Surprise me toggles all categories, "Create invite link" submits and shows the share-link screen.
- [ ] Manual: open a share link in a new window (Person B) — verify raspberry layout, invitation banner shows creator's initial + name, "Use my location" populates the field, form validation prevents submit until name + location + at least one category are set, "Join this date plan" submits and advances to the loading screen.
- [ ] \`bun run lint\` passes (no new warnings introduced).
- [ ] Existing test suite runs (pre-existing failures in other test files are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)