### PR TITLE
feat: enrich venue data with editorial summary, distance, hours, why-picked

### DIFF
--- a/web-service/src/app/globals.css
+++ b/web-service/src/app/globals.css
@@ -3,25 +3,59 @@
 /* ---------------------------------------------------------------------------
  * Dateflow Design Tokens
  *
- * Every color, font size, and spacing value used in the app lives here.
- * Components reference these via Tailwind utilities (e.g., bg-primary,
- * text-heading1) instead of hardcoding hex values.
+ * Two role palettes (Person A = brown, Person B = raspberry) share a common
+ * dark wine canvas. Legacy semantic tokens (bg, surface, primary, secondary,
+ * text) have been reassigned so components inherit the new look without
+ * per-file rewrites. Role-specific gradients opt in via CSS vars below.
  * --------------------------------------------------------------------------- */
 
 :root {
-  /* Colors — two-accent system (coral + teal) */
-  --color-bg: #FAF8F5;
-  --color-surface: #FFFFFF;
-  --color-primary: #E07468;
-  --color-primary-hover: #C9625A;
-  --color-primary-muted: #E0746833;
-  --color-secondary: #5B9A8B;
-  --color-secondary-muted: #5B9A8B1A;
-  --color-muted: #D5D0CA;
-  --color-text: #2D2A26;
-  --color-text-secondary: #7A756E;
-  --color-success: #4CAF7A;
-  --color-error: #C94545;
+  /* Role palette — Person A (rich brown) */
+  --brown-50: #efe5de;
+  --brown-200: #c9a899;
+  --brown-400: #8a5a4a;
+  --brown-600: #4a302a;
+  --brown-800: #2a1a15;
+  --brown-900: #1a0f0c;
+
+  /* Role palette — Person B (raspberry) */
+  --raspberry-50: #f8d6e0;
+  --raspberry-200: #e88aa6;
+  --raspberry-400: #d03d6a;
+  --raspberry-600: #8a2346;
+  --raspberry-800: #4a1224;
+  --raspberry-900: #2d0a18;
+
+  /* Shared neutral — dark wine that plays with both brown and raspberry */
+  --wine-bg: #1a0f10;
+  --wine-surface: #2a1a1c;
+  --wine-card: #33202a;
+  --wine-border: #3a2a2f;
+
+  /* Glass tokens — for translucent cards layered on gradient canvases */
+  --glass-fill: rgba(255, 255, 255, 0.06);
+  --glass-fill-strong: rgba(255, 255, 255, 0.1);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-border-strong: rgba(255, 255, 255, 0.28);
+
+  /* Hot accent — the pink CTA glow from the Person B landing */
+  --accent-hot: #ff3d7f;
+  --accent-hot-soft: rgba(255, 61, 127, 0.35);
+
+  /* Semantic tokens — reassigned to the new palette */
+  --color-bg: var(--wine-bg);
+  --color-surface: var(--wine-surface);
+  --color-primary: var(--raspberry-400);
+  --color-primary-hover: #b83057;
+  --color-primary-muted: rgba(208, 61, 106, 0.22);
+  --color-secondary: #e8a08a; /* warm terracotta — pairs with both brown & raspberry */
+  --color-secondary-muted: rgba(232, 160, 138, 0.18);
+  --color-muted: var(--wine-border);
+  --color-text: #f5ebe3;
+  --color-text-secondary: #b8a598;
+  --color-success: #6bd9a4;
+  --color-error: #ff8585;
+
   --motion-fast: 180ms;
   --motion-base: 240ms;
   --motion-slow: 320ms;
@@ -30,7 +64,6 @@
 }
 
 @theme inline {
-  /* Colors — maps CSS vars to Tailwind classes (bg-primary, text-text, etc.) */
   --color-bg: var(--color-bg);
   --color-surface: var(--color-surface);
   --color-primary: var(--color-primary);
@@ -43,11 +76,16 @@
   --color-text-secondary: var(--color-text-secondary);
   --color-success: var(--color-success);
   --color-error: var(--color-error);
+  --color-brown-600: var(--brown-600);
+  --color-brown-800: var(--brown-800);
+  --color-brown-900: var(--brown-900);
+  --color-raspberry-400: var(--raspberry-400);
+  --color-raspberry-600: var(--raspberry-600);
+  --color-raspberry-800: var(--raspberry-800);
+  --color-accent-hot: var(--accent-hot);
 
-  /* Typography — font family */
   --font-sans: var(--font-inter);
 
-  /* Typography — font sizes with line-height baked in */
   --text-display: 36px;
   --text-display--line-height: 1.2;
   --text-h1: 28px;
@@ -58,6 +96,19 @@
   --text-body--line-height: 1.5;
   --text-caption: 14px;
   --text-caption--line-height: 1.5;
+}
+
+/* Utility gradients for role-aware surfaces — apply as bg via arbitrary value */
+.bg-person-a {
+  background: radial-gradient(circle at top, var(--brown-600) 0%, var(--brown-800) 55%, var(--brown-900) 100%);
+}
+
+.bg-person-b {
+  background: radial-gradient(circle at top, var(--raspberry-400) 0%, var(--raspberry-600) 55%, var(--raspberry-800) 100%);
+}
+
+.bg-shared-wine {
+  background: radial-gradient(circle at top, #2d1a20 0%, var(--wine-bg) 70%, #140a0c 100%);
 }
 
 body {

--- a/web-service/src/app/history/history-page.tsx
+++ b/web-service/src/app/history/history-page.tsx
@@ -118,38 +118,38 @@ export function HistoryPage({
   }, [includeAll, page]);
 
   return (
-    <main className="min-h-dvh bg-bg text-text">
+    <main className="bg-shared-wine min-h-dvh text-white">
       <div className="mx-auto flex w-full max-w-6xl flex-col px-6 pb-16 pt-8 sm:px-8">
         <header className="flex items-center justify-between">
           <Logo />
-          <span className="rounded-full border border-white/60 bg-white/80 px-3 py-1 text-caption text-text-secondary shadow-sm backdrop-blur">
+          <span className="rounded-full border border-white/15 bg-white/[0.06] px-3 py-1 text-caption text-white/70 backdrop-blur">
             Saved dates
           </span>
         </header>
 
         <section className="mt-10 max-w-3xl">
-          <p className="text-caption font-semibold uppercase tracking-[0.22em] text-secondary">
+          <p className="text-caption font-semibold uppercase tracking-[0.28em] text-white/65">
             History
           </p>
-          <h1 className="mt-4 text-[clamp(2.75rem,8vw,4.5rem)] font-semibold leading-[0.95] tracking-[-0.05em]">
+          <h1 className="mt-4 text-[clamp(2.75rem,8vw,4.5rem)] font-semibold leading-[0.95] tracking-[-0.05em] text-white">
             Saved dates
           </h1>
-          <p className="mt-4 text-body text-text-secondary">
+          <p className="mt-4 text-body text-white/70">
             Keep every promising plan in one place, then come back when you need the details again.
           </p>
           {accountEmail ? (
-            <p className="mt-4 text-caption font-medium text-text-secondary">
+            <p className="mt-4 text-caption font-medium text-white/60">
               Signed in as {accountEmail}
             </p>
           ) : null}
         </section>
 
         {tokenState === "missing" ? (
-          <section className="mt-10 rounded-[2rem] border border-white/70 bg-white/90 p-6 shadow-[0_18px_50px_rgba(45,42,38,0.08)]">
-            <h2 className="text-h2 font-semibold text-text">
+          <section className="mt-10 rounded-[2rem] border border-white/15 bg-white/[0.06] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.35)] backdrop-blur-md">
+            <h2 className="text-h2 font-semibold text-white">
               Sign in to view your saved dates
             </h2>
-            <p className="mt-3 max-w-2xl text-body text-text-secondary">
+            <p className="mt-3 max-w-2xl text-body text-white/70">
               Your match history only appears after you create an account or log in from a saved result.
             </p>
           </section>
@@ -179,17 +179,17 @@ export function HistoryPage({
             </div>
 
             {loading ? (
-              <section className="mt-8 rounded-[2rem] border border-white/70 bg-white/90 p-6 shadow-[0_18px_50px_rgba(45,42,38,0.08)]">
-                <p className="text-body text-text-secondary">Loading your saved dates...</p>
+              <section className="mt-8 rounded-[2rem] border border-white/15 bg-white/[0.06] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.35)] backdrop-blur-md">
+                <p className="text-body text-white/70">Loading your saved dates...</p>
               </section>
             ) : error ? (
               <section className="mt-8 rounded-[2rem] border border-error/15 bg-white/90 p-6 shadow-[0_18px_50px_rgba(45,42,38,0.08)]">
                 <p className="text-body text-error">{error}</p>
               </section>
             ) : history && history.sessions.length === 0 ? (
-              <section className="mt-8 rounded-[2rem] border border-white/70 bg-white/90 p-6 shadow-[0_18px_50px_rgba(45,42,38,0.08)]">
-                <h2 className="text-h2 font-semibold text-text">No saved dates yet</h2>
-                <p className="mt-3 max-w-2xl text-body text-text-secondary">
+              <section className="mt-8 rounded-[2rem] border border-white/15 bg-white/[0.06] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.35)] backdrop-blur-md">
+                <h2 className="text-h2 font-semibold text-white">No saved dates yet</h2>
+                <p className="mt-3 max-w-2xl text-body text-white/70">
                   Your future matches will show up here once you save them from the result page.
                 </p>
               </section>

--- a/web-service/src/app/plan/[id]/results/result-screen.tsx
+++ b/web-service/src/app/plan/[id]/results/result-screen.tsx
@@ -198,7 +198,7 @@ export function ResultScreen({
   }
 
   return (
-    <main className="relative min-h-dvh overflow-hidden bg-bg text-text">
+    <main className="bg-shared-wine relative min-h-dvh overflow-hidden text-white">
       <AuthSheet
         open={authOpen}
         mode={authMode}
@@ -231,7 +231,7 @@ export function ResultScreen({
       <div className="mx-auto flex min-h-dvh w-full max-w-[54rem] flex-col px-4 pb-12 pt-6 sm:px-6 sm:pt-8">
         <header className="flex items-center justify-between">
           <Logo />
-          <span className="rounded-full border border-white/70 bg-white/85 px-3 py-1 text-caption text-text-secondary shadow-sm backdrop-blur">
+          <span className="rounded-full border border-white/15 bg-white/[0.06] px-3 py-1 text-caption text-white/70 backdrop-blur">
             Shared result
           </span>
         </header>
@@ -246,22 +246,22 @@ export function ResultScreen({
                   : "resultReveal 520ms cubic-bezier(0.2, 1, 0.22, 1) both",
             }}
           >
-            <div className="border-b border-[#E7DDD2] pb-8 text-center">
-              <p className="text-caption font-semibold uppercase tracking-[0.22em] text-text-secondary">
+            <div className="border-b border-white/12 pb-8 text-center">
+              <p className="text-caption font-semibold uppercase tracking-[0.22em] text-white/65">
                 Match reveal
               </p>
               <div className="mt-6 flex items-center justify-center gap-4">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#F8D8D0]">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[rgba(255,61,127,0.22)] backdrop-blur-sm">
                   <HeartIcon className="h-5 w-5 text-primary" />
                 </div>
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#DDEBE6]">
-                  <HeartIcon className="h-5 w-5 text-secondary" />
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[rgba(232,160,138,0.22)] backdrop-blur-sm">
+                  <HeartIcon className="h-5 w-5 text-white" />
                 </div>
               </div>
-              <h1 className="mt-5 text-[clamp(2.6rem,8vw,3.5rem)] leading-[0.95] tracking-[-0.04em] text-text [font-family:Georgia,'Times_New_Roman',serif]">
+              <h1 className="mt-5 text-[clamp(2.6rem,8vw,3.5rem)] leading-[0.95] tracking-[-0.04em] text-white [font-family:Georgia,'Times_New_Roman',serif]">
                 It&apos;s a match!
               </h1>
-              <p className="mt-3 text-[1.15rem] text-text-secondary">
+              <p className="mt-3 text-[1.15rem] text-white/65">
                 {matchedWithName ? (
                   <>
                     You and <span className="text-primary">{matchedWithName}</span> both loved this spot
@@ -272,8 +272,8 @@ export function ResultScreen({
               </p>
             </div>
 
-            <div className="mt-7 overflow-hidden rounded-[2rem] border border-[#E7DDD2] bg-white shadow-[0_18px_50px_rgba(45,42,38,0.08)]">
-              <div className="relative aspect-[4/3] overflow-hidden bg-[#E9E1D7]">
+            <div className="mt-7 overflow-hidden rounded-[2rem] border border-white/15 bg-white/[0.06] shadow-[0_30px_80px_rgba(0,0,0,0.4)] backdrop-blur-md">
+              <div className="relative aspect-[4/3] overflow-hidden bg-white/[0.08]">
                 {heroImage ? (
                   <Image
                     src={heroImage}
@@ -286,20 +286,20 @@ export function ResultScreen({
                 ) : null}
                 <button
                   type="button"
-                  className="absolute right-4 top-4 flex h-11 w-11 items-center justify-center rounded-full bg-white/92 text-text shadow-[0_8px_18px_rgba(45,42,38,0.14)]"
+                  className="absolute right-4 top-4 flex h-11 w-11 items-center justify-center rounded-full bg-white/90 text-[#4a1224] shadow-[0_10px_24px_rgba(0,0,0,0.4)]"
                 >
                   <BookmarkIcon />
                 </button>
               </div>
 
               <div className="px-6 pb-6 pt-5">
-                <div className="inline-flex rounded-full bg-[#E6F0EB] px-3 py-1 text-caption font-semibold text-secondary">
+                <div className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-caption font-semibold text-white backdrop-blur-sm">
                   {venueTypeLabel}
                 </div>
-                <h2 className="mt-4 text-[clamp(2rem,6vw,2.9rem)] leading-[0.98] tracking-[-0.04em] text-text [font-family:Georgia,'Times_New_Roman',serif]">
+                <h2 className="mt-4 text-[clamp(2rem,6vw,2.9rem)] leading-[0.98] tracking-[-0.04em] text-white [font-family:Georgia,'Times_New_Roman',serif]">
                   {venue.name}
                 </h2>
-                <div className="mt-4 grid gap-4 text-body text-text-secondary sm:grid-cols-2">
+                <div className="mt-4 grid gap-4 text-body text-white/65 sm:grid-cols-2">
                   <div className="flex items-start gap-3">
                     <LocationPinIcon />
                     <span>{venue.address}</span>
@@ -312,14 +312,14 @@ export function ResultScreen({
               </div>
             </div>
 
-            <div className="mt-6 rounded-[1.5rem] border border-[#ECE3D9] bg-white px-5 py-5 shadow-[0_14px_36px_rgba(45,42,38,0.06)]">
+            <div className="mt-6 rounded-[1.5rem] border border-white/12 bg-white/[0.06] px-5 py-5 shadow-[0_24px_56px_rgba(0,0,0,0.35)] backdrop-blur-md">
               <div className="flex items-start gap-3">
-                <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[linear-gradient(135deg,#D98E7A,#7A9B8E)] text-white">
+                <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[linear-gradient(135deg,#d03d6a,#8a5a4a)] text-white">
                   <HeartIcon className="h-3.5 w-3.5" />
                 </div>
                 <div>
-                  <p className="text-[1.15rem] font-semibold text-text">Why this works</p>
-                  <p className="mt-2 text-[1rem] leading-8 text-text-secondary">
+                  <p className="text-[1.15rem] font-semibold text-white">Why this works</p>
+                  <p className="mt-2 text-[1rem] leading-8 text-white/65">
                     Both of you liked activity-forward options. This spot feels playful, memorable, and makes conversation easy, perfect for breaking the ice.
                   </p>
                 </div>
@@ -346,7 +346,7 @@ export function ResultScreen({
                   <Button
                     variant="secondary"
                     icon={<CalendarIcon />}
-                    className="h-12 w-full rounded-[1rem] !border-0 !bg-[#E7EFE9] !text-secondary shadow-none hover:!bg-[#dbe9e1]"
+                    className="h-12 w-full rounded-[1rem] !border !border-white/20 !bg-white/[0.08] !text-white !shadow-none hover:!bg-white/[0.14]"
                   >
                     Calendar
                   </Button>
@@ -357,16 +357,16 @@ export function ResultScreen({
             {galleryImages.length > 1 ? (
               <section className="mt-6" aria-label="Photo gallery">
                 <div className="flex items-center justify-between gap-3">
-                  <p className="text-caption font-semibold uppercase tracking-[0.2em] text-text-secondary">
+                  <p className="text-caption font-semibold uppercase tracking-[0.2em] text-white/65">
                     Photo gallery
                   </p>
-                  <p className="text-caption text-text-secondary">{galleryImages.length} photos</p>
+                  <p className="text-caption text-white/65">{galleryImages.length} photos</p>
                 </div>
                 <div className="mt-3 grid grid-cols-3 gap-2.5">
                   {galleryImages.slice(0, 3).map((photoUrl, photoIndex) => (
                     <div
                       key={`${photoUrl}-${photoIndex}`}
-                      className="relative aspect-square overflow-hidden rounded-[1rem] bg-[#E9E1D7]"
+                      className="relative aspect-square overflow-hidden rounded-[1rem] border border-white/10 bg-white/[0.06]"
                     >
                       <Image
                         src={photoUrl}
@@ -385,48 +385,48 @@ export function ResultScreen({
 
           {authStatus === "saved" ? (
             <section
-              className="mt-6 rounded-[1.5rem] border border-[#F0E6DC] bg-[linear-gradient(180deg,rgba(249,243,238,0.98),rgba(245,240,234,0.92))] px-6 py-6 text-center shadow-[0_14px_36px_rgba(45,42,38,0.06)]"
+              className="mt-6 rounded-[1.5rem] border border-white/15 bg-white/[0.06] px-6 py-6 text-center shadow-[0_24px_60px_rgba(0,0,0,0.4)] backdrop-blur-md"
               style={{
                 animation:
                   "savePromptReveal var(--motion-base) var(--ease-enter) both",
               }}
             >
-              <p className="text-caption font-semibold uppercase tracking-[0.24em] text-text-secondary">
+              <p className="text-caption font-semibold uppercase tracking-[0.24em] text-white/65">
                 Saved to your history
               </p>
-              <div className="mx-auto mt-4 flex h-12 w-12 items-center justify-center rounded-full bg-[linear-gradient(135deg,#D98E7A,#7A9B8E)] text-white">
+              <div className="mx-auto mt-4 flex h-12 w-12 items-center justify-center rounded-full bg-[linear-gradient(135deg,#d03d6a,#8a5a4a)] text-white">
                 <HeartIcon className="h-5 w-5" />
               </div>
-              <h2 className="mt-5 text-[2rem] leading-[1.05] tracking-[-0.03em] text-text [font-family:Georgia,'Times_New_Roman',serif]">
+              <h2 className="mt-5 text-[2rem] leading-[1.05] tracking-[-0.03em] text-white [font-family:Georgia,'Times_New_Roman',serif]">
                 This date is saved
               </h2>
-              <p className="mx-auto mt-3 max-w-sm text-[1rem] leading-7 text-text-secondary">
+              <p className="mx-auto mt-3 max-w-sm text-[1rem] leading-7 text-white/65">
                 Come back to this plan anytime. Future matches will save here too.
               </p>
               {accountEmail ? (
-                <p className="mt-4 text-[0.98rem] text-text-secondary">
+                <p className="mt-4 text-[0.98rem] text-white/65">
                   Signed in as {accountEmail}
                 </p>
               ) : null}
             </section>
           ) : (
             <section
-              className="mt-6 rounded-[1.5rem] border border-[#F0E6DC] bg-[linear-gradient(180deg,rgba(249,243,238,0.98),rgba(245,240,234,0.92))] px-6 py-6 text-center shadow-[0_14px_36px_rgba(45,42,38,0.06)]"
+              className="mt-6 rounded-[1.5rem] border border-white/15 bg-white/[0.06] px-6 py-6 text-center shadow-[0_24px_60px_rgba(0,0,0,0.4)] backdrop-blur-md"
               style={{
                 animation:
                   "savePromptReveal var(--motion-base) var(--ease-enter) 120ms both",
               }}
             >
-              <p className="text-caption font-semibold uppercase tracking-[0.24em] text-text-secondary">
+              <p className="text-caption font-semibold uppercase tracking-[0.24em] text-white/65">
                 Save this date
               </p>
-              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[linear-gradient(135deg,#D98E7A,#7A9B8E)] text-white">
+              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[linear-gradient(135deg,#d03d6a,#8a5a4a)] text-white">
                 <HeartIcon className="h-5 w-5" />
               </div>
-              <h2 className="mt-5 text-[2rem] leading-[1.05] tracking-[-0.03em] text-text [font-family:Georgia,'Times_New_Roman',serif]">
+              <h2 className="mt-5 text-[2rem] leading-[1.05] tracking-[-0.03em] text-white [font-family:Georgia,'Times_New_Roman',serif]">
                 Save your date plans
               </h2>
-              <p className="mx-auto mt-3 max-w-sm text-[1rem] leading-7 text-text-secondary">
+              <p className="mx-auto mt-3 max-w-sm text-[1rem] leading-7 text-white/65">
                 Create an account to save this plan and track all your future dates in one place
               </p>
 
@@ -438,13 +438,13 @@ export function ResultScreen({
                     setAuthError(null);
                     setAuthOpen(true);
                   }}
-                  className="h-11 rounded-[0.95rem] bg-[#25201C] text-[1rem] text-white hover:bg-[#1d1916]"
+                  className="h-11 rounded-[0.95rem] bg-[#4a1224] text-[1rem] text-white hover:bg-[#3a0e1c]"
                 >
                   Create account
                 </Button>
               </div>
 
-              <div className="mt-4 flex items-center justify-center gap-4 text-caption text-text-secondary">
+              <div className="mt-4 flex items-center justify-center gap-4 text-caption text-white/65">
                 <button
                   type="button"
                   onClick={() => {
@@ -453,11 +453,11 @@ export function ResultScreen({
                     setAuthError(null);
                     setAuthOpen(true);
                   }}
-                  className="cursor-pointer underline decoration-[#CFC4B9] underline-offset-4"
+                  className="cursor-pointer underline decoration-white/30 underline-offset-4"
                 >
                   Log in
                 </button>
-                <span className="text-[#C7BDB3]">•</span>
+                <span className="text-white/35">•</span>
                 <span>Continue without account</span>
               </div>
             </section>

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -984,7 +984,8 @@ export function formatRatingWithCount(
   if (typeof reviewCount !== "number" || reviewCount <= 0) {
     return `${ratingLabel} rating`;
   }
-  return `${ratingLabel} · ${formatReviewCount(reviewCount)} reviews`;
+  const reviewLabel = reviewCount === 1 ? "review" : "reviews";
+  return `${ratingLabel} · ${formatReviewCount(reviewCount)} ${reviewLabel}`;
 }
 
 function formatReviewCount(count: number): string {

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -469,16 +469,37 @@ export function SwipeDeckCard({
                     {venue.name}
                   </h2>
                   <p className="mt-2 text-body text-[#6a4a3a]">{venue.address}</p>
+                  {venue.editorialSummary ? (
+                    <p className="mt-2 line-clamp-2 text-body italic text-[#8a6a5a]">
+                      {venue.editorialSummary}
+                    </p>
+                  ) : null}
                 </div>
                 <div className="mt-4 flex flex-wrap gap-2">
                   <InfoPill>
                     <StarIcon />
-                    {venue.rating.toFixed(1)} rating
+                    {formatRatingWithCount(venue.rating, venue.userRatingCount)}
                   </InfoPill>
                   <InfoPill>
                     <CategoryIcon category={venue.category} />
                     {CATEGORY_LABELS[venue.category]}
                   </InfoPill>
+                  {typeof venue.distanceMeters === "number" ? (
+                    <InfoPill>{formatDistance(venue.distanceMeters)}</InfoPill>
+                  ) : null}
+                  {venue.openingHours ? (
+                    <InfoPill>
+                      <span
+                        className={`inline-block h-2 w-2 rounded-full ${
+                          venue.openingHours.openNow
+                            ? "bg-[#10a37f]"
+                            : "bg-[#c2410c]"
+                        }`}
+                        aria-hidden="true"
+                      />
+                      {venue.openingHours.openNow ? "Open now" : "Closed"}
+                    </InfoPill>
+                  ) : null}
                   <InfoPill>{`Round ${venue.round}`}</InfoPill>
                 </div>
               </div>
@@ -547,6 +568,15 @@ export function SwipeDeckCard({
               </span>
             ))}
           </div>
+
+          {venue.whyPicked ? (
+            <div className="rounded-[1.25rem] border border-[rgba(208,61,106,0.25)] bg-[rgba(208,61,106,0.08)] p-4">
+              <p className="text-caption font-semibold uppercase tracking-[0.16em] text-[#8a2346]">
+                Why we picked this
+              </p>
+              <p className="mt-2 text-body text-[#2a1a1c]">{venue.whyPicked}</p>
+            </div>
+          ) : null}
 
           <div className="grid grid-cols-2 gap-3">
             <button
@@ -944,4 +974,33 @@ function getActionButtonStyle(
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
+}
+
+export function formatRatingWithCount(
+  rating: number,
+  reviewCount: number | undefined,
+): string {
+  const ratingLabel = `${rating.toFixed(1)}`;
+  if (typeof reviewCount !== "number" || reviewCount <= 0) {
+    return `${ratingLabel} rating`;
+  }
+  return `${ratingLabel} · ${formatReviewCount(reviewCount)} reviews`;
+}
+
+function formatReviewCount(count: number): string {
+  if (count >= 1_000) {
+    const thousands = count / 1_000;
+    const rounded =
+      thousands >= 10 ? Math.round(thousands) : Math.round(thousands * 10) / 10;
+    return `${rounded}k`;
+  }
+  return String(count);
+}
+
+export function formatDistance(meters: number): string {
+  const miles = meters / 1609.344;
+  if (miles < 0.1) {
+    return "<0.1 mi away";
+  }
+  return `${miles.toFixed(1)} mi away`;
 }

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -346,8 +346,8 @@ export function SwipeDeckCard({
             opacity: Math.max(dragStrength * 0.9, animatingSwipe ? 0.45 : 0),
             background:
               dragRatio >= 0
-                ? `linear-gradient(135deg, rgba(224,116,104,${0.12 + dragStrength * 0.24}), rgba(224,116,104,0) 60%)`
-                : `linear-gradient(225deg, rgba(91,154,139,${0.12 + dragStrength * 0.24}), rgba(91,154,139,0) 60%)`,
+                ? `linear-gradient(135deg, rgba(16,163,127,${0.14 + dragStrength * 0.26}), rgba(16,163,127,0) 60%)`
+                : `linear-gradient(225deg, rgba(220,53,69,${0.14 + dragStrength * 0.26}), rgba(220,53,69,0) 60%)`,
             transition: isDragging ? "opacity 70ms linear" : "opacity 180ms ease",
           }}
         />
@@ -556,7 +556,7 @@ export function SwipeDeckCard({
                 void triggerSwipe(false);
               }}
               disabled={submitting || Boolean(animatingSwipe)}
-              className="h-14 rounded-2xl border-white/80 bg-white/92 shadow-[0_12px_28px_rgba(45,42,38,0.06)]"
+              className="h-14 rounded-2xl border-[rgba(220,53,69,0.35)] bg-[rgba(220,53,69,0.08)] text-[#b22233] shadow-[0_12px_28px_rgba(220,53,69,0.15)] hover:bg-[rgba(220,53,69,0.14)]"
               style={getActionButtonStyle("left", dragRatio, neutralReturnStrength)}
             >
               <span className="flex items-center gap-2">
@@ -569,7 +569,7 @@ export function SwipeDeckCard({
                 void triggerSwipe(true);
               }}
               disabled={submitting || Boolean(animatingSwipe)}
-              className="h-14 rounded-2xl shadow-[0_14px_30px_rgba(224,116,104,0.24)]"
+              className="h-14 rounded-2xl border-transparent bg-[#10a37f] text-white shadow-[0_14px_30px_rgba(16,163,127,0.32)] hover:bg-[#0e8e6f]"
               style={getActionButtonStyle("right", dragRatio, neutralReturnStrength)}
             >
               <span className="flex items-center gap-2">
@@ -599,8 +599,8 @@ function SwipeIntentBadge({
     <div
       className={`rounded-full border px-4 py-2 text-caption font-semibold uppercase tracking-[0.18em] shadow-sm backdrop-blur-sm transition-all duration-150 ${
         tone === "like"
-          ? "border-white/68 bg-white/92 text-primary"
-          : "border-white/55 bg-black/36 text-white"
+          ? "border-[rgba(16,163,127,0.6)] bg-[rgba(16,163,127,0.92)] text-white"
+          : "border-[rgba(220,53,69,0.6)] bg-[rgba(220,53,69,0.92)] text-white"
       }`}
       style={{
         opacity: visible ? 1 : 0,
@@ -930,8 +930,8 @@ function getActionButtonStyle(
     transform: `translateY(${translateY}px) scale(${emphasis > 0 ? activeScale : restingScale})`,
     boxShadow:
       direction === "right"
-        ? `0 16px 34px rgba(224,116,104,${shadowAlpha})`
-        : `0 14px 30px rgba(45,42,38,${shadowAlpha})`,
+        ? `0 16px 34px rgba(16,163,127,${shadowAlpha})`
+        : `0 14px 30px rgba(220,53,69,${shadowAlpha})`,
     transition:
       "transform 180ms cubic-bezier(0.18, 0.86, 0.24, 1), box-shadow 180ms ease, background-color 180ms ease",
   };

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -709,25 +709,34 @@ function StarIcon() {
 function PassIcon() {
   return (
     <svg
-      className="h-5 w-5"
+      className="h-[22px] w-[22px]"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth="2"
+      strokeWidth="2.4"
       strokeLinecap="round"
       strokeLinejoin="round"
       aria-hidden="true"
     >
-      <path d="M18 6 6 18" />
-      <path d="m6 6 12 12" />
+      <circle cx="12" cy="12" r="9.25" />
+      <path d="M8.5 8.5 15.5 15.5" />
+      <path d="M15.5 8.5 8.5 15.5" />
     </svg>
   );
 }
 
 function HeartIcon() {
   return (
-    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-      <path d="M12 21s-6.72-4.32-9.33-8.35C.96 10.01 1.53 6.5 4.43 4.84c2.35-1.35 4.85-.48 6.1 1.33 1.25-1.81 3.75-2.68 6.1-1.33 2.9 1.66 3.47 5.17 1.76 7.81C18.72 16.68 12 21 12 21Z" />
+    <svg
+      className="h-[22px] w-[22px]"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 20.5c-.5 0-.98-.19-1.35-.53-2.5-2.3-4.6-4.2-6.07-6.08C3.14 12.04 2.5 10.4 2.5 8.75c0-2.9 2.24-5.25 5-5.25 1.77 0 3.38.92 4.25 2.33.87-1.41 2.48-2.33 4.25-2.33 2.76 0 5 2.35 5 5.25 0 1.65-.64 3.29-2.08 5.14-1.47 1.88-3.57 3.78-6.07 6.08-.37.34-.85.53-1.35.53Z" />
     </svg>
   );
 }

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -302,7 +302,7 @@ export function SwipeDeckCard({
 
       <article
         ref={cardRef}
-        className={`relative overflow-hidden rounded-[2rem] border border-white/72 bg-white/92 backdrop-blur-sm ${
+        className={`relative overflow-hidden rounded-[2rem] border border-white/60 bg-white/95 shadow-[0_30px_80px_rgba(74,18,36,0.45)] backdrop-blur-sm ${
           submitting ? "pointer-events-none" : "cursor-grab active:cursor-grabbing"
         }`}
         style={{
@@ -459,11 +459,11 @@ export function SwipeDeckCard({
         </div>
 
         <div className="space-y-4 p-6">
-          <div className="rounded-[1.5rem] border border-[#d9c7b5] bg-[#f5ebe3]/80 p-4">
+          <div className="rounded-[1.5rem] border border-[rgba(208,61,106,0.18)] bg-[rgba(208,61,106,0.05)] p-4">
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0 space-y-3">
                 <div>
-                  <p className="text-caption font-semibold uppercase tracking-[0.16em] text-[#6a4a3a]">
+                  <p className="text-caption font-semibold uppercase tracking-[0.16em] text-[#8a2346]">
                     Venue {cardIndex} of {totalCards}
                   </p>
                   <h2 className="mt-2 text-[clamp(1.9rem,4vw,2.5rem)] font-semibold leading-[0.98] tracking-[-0.04em] text-[#2a1a1c]">
@@ -539,10 +539,10 @@ export function SwipeDeckCard({
           ) : null}
 
           <div className="flex flex-wrap gap-2">
-            {venue.tags.slice(0, 3).map((tag) => (
+            {getDisplayTags(venue.tags).slice(0, 3).map((tag) => (
               <span
                 key={tag}
-                className="rounded-full border border-[#d9c7b5] bg-[#f5ebe3] px-3 py-1.5 text-caption font-medium text-[#6a4a3a]"
+                className="rounded-full border border-[rgba(208,61,106,0.3)] bg-[rgba(208,61,106,0.08)] px-3 py-1.5 text-caption font-medium text-[#8a2346]"
               >
                 {tag}
               </span>
@@ -663,10 +663,10 @@ function PreviewVenueCard({
             <StarIcon />
             {venue.rating.toFixed(1)}
           </div>
-          {venue.tags.slice(0, 2).map((tag) => (
+          {getDisplayTags(venue.tags).slice(0, 2).map((tag) => (
             <div
               key={tag}
-              className="rounded-full border border-[#d9c7b5] bg-white px-2.5 py-1 text-caption text-[#6a4a3a]"
+              className="rounded-full border border-[rgba(208,61,106,0.3)] bg-[rgba(208,61,106,0.08)] px-2.5 py-1 text-caption text-[#8a2346]"
             >
               {tag}
             </div>
@@ -677,9 +677,26 @@ function PreviewVenueCard({
   );
 }
 
+// Internal markers emitted by the scoring pipeline that should never reach the
+// user-facing venue card.
+const INTERNAL_TAGS = new Set<string>([
+  "unscored",
+  "ai-curated",
+  "top-rated",
+  "well-reviewed",
+  "restaurant",
+  "bar",
+  "activity",
+  "event",
+]);
+
+function getDisplayTags(tags: readonly string[]): readonly string[] {
+  return tags.filter((tag) => !INTERNAL_TAGS.has(tag.toLowerCase()));
+}
+
 function InfoPill({ children }: { readonly children: React.ReactNode }) {
   return (
-    <div className="inline-flex items-center gap-2 rounded-full border border-[#d9c7b5] bg-white px-3 py-1.5 text-caption font-medium text-[#6a4a3a]">
+    <div className="inline-flex items-center gap-2 rounded-full border border-[rgba(208,61,106,0.25)] bg-white px-3 py-1.5 text-caption font-medium text-[#8a2346]">
       {children}
     </div>
   );

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -417,7 +417,7 @@ export function SwipeDeckCard({
             }}
           />
 
-          <div className="absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-white/90 px-3 py-2 text-caption font-medium text-text shadow-sm">
+          <div className="absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-white/90 px-3 py-2 text-caption font-medium text-[#2a1a1c] shadow-sm">
             <CategoryIcon category={venue.category} />
             {CATEGORY_LABELS[venue.category]}
           </div>
@@ -459,17 +459,17 @@ export function SwipeDeckCard({
         </div>
 
         <div className="space-y-4 p-6">
-          <div className="rounded-[1.5rem] border border-muted bg-bg/72 p-4">
+          <div className="rounded-[1.5rem] border border-[#d9c7b5] bg-[#f5ebe3]/80 p-4">
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0 space-y-3">
                 <div>
-                  <p className="text-caption font-semibold uppercase tracking-[0.16em] text-text-secondary">
+                  <p className="text-caption font-semibold uppercase tracking-[0.16em] text-[#6a4a3a]">
                     Venue {cardIndex} of {totalCards}
                   </p>
-                  <h2 className="mt-2 text-[clamp(1.9rem,4vw,2.5rem)] font-semibold leading-[0.98] tracking-[-0.04em] text-text">
+                  <h2 className="mt-2 text-[clamp(1.9rem,4vw,2.5rem)] font-semibold leading-[0.98] tracking-[-0.04em] text-[#2a1a1c]">
                     {venue.name}
                   </h2>
-                  <p className="mt-2 text-body text-text-secondary">{venue.address}</p>
+                  <p className="mt-2 text-body text-[#6a4a3a]">{venue.address}</p>
                 </div>
                 <div className="mt-4 flex flex-wrap gap-2">
                   <InfoPill>
@@ -492,7 +492,7 @@ export function SwipeDeckCard({
           {currentSlides.length > 1 ? (
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-3">
-                <p className="text-caption font-semibold uppercase tracking-[0.16em] text-text-secondary">
+                <p className="text-caption font-semibold uppercase tracking-[0.16em] text-[#6a4a3a]">
                   Venue photos
                 </p>
                 <div className="flex items-center gap-1.5">
@@ -517,10 +517,10 @@ export function SwipeDeckCard({
                     type="button"
                     key={`${slide}-thumb-${slideIndex}`}
                     aria-label={`Show photo ${slideIndex + 1} of ${currentSlides.length}`}
-                    className={`relative h-20 min-w-24 overflow-hidden rounded-[1.1rem] border bg-bg shadow-[0_10px_24px_rgba(45,42,38,0.08)] ${
+                    className={`relative h-20 min-w-24 overflow-hidden rounded-[1.1rem] border bg-[#f5ebe3] shadow-[0_10px_24px_rgba(45,42,38,0.08)] ${
                       slideIndex === activeSlideIndex
                         ? "border-primary ring-2 ring-primary/20"
-                        : "border-muted"
+                        : "border-[#d9c7b5]"
                     }`}
                     onClick={() => moveToSlide(slideIndex)}
                   >
@@ -542,7 +542,7 @@ export function SwipeDeckCard({
             {venue.tags.slice(0, 3).map((tag) => (
               <span
                 key={tag}
-                className="rounded-full border border-muted bg-bg px-3 py-1.5 text-caption font-medium text-text-secondary"
+                className="rounded-full border border-[#d9c7b5] bg-[#f5ebe3] px-3 py-1.5 text-caption font-medium text-[#6a4a3a]"
               >
                 {tag}
               </span>
@@ -642,7 +642,7 @@ function PreviewVenueCard({
           </>
         )}
         <div className="absolute inset-x-0 bottom-0 h-20 bg-[linear-gradient(180deg,transparent,rgba(255,255,255,0.94))]" />
-        <div className="absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-white/88 px-3 py-2 text-caption text-text-secondary shadow-sm">
+        <div className="absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-white/88 px-3 py-2 text-caption text-[#6a4a3a] shadow-sm">
           <CategoryIcon category={venue.category} />
           {CATEGORY_LABELS[venue.category]}
         </div>
@@ -651,22 +651,22 @@ function PreviewVenueCard({
       <div className="space-y-4 px-5 py-5">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
-            <p className="text-body font-semibold text-text">{venue.name}</p>
-            <p className="mt-1 text-caption text-text-secondary">{venue.address}</p>
+            <p className="text-body font-semibold text-[#2a1a1c]">{venue.name}</p>
+            <p className="mt-1 text-caption text-[#6a4a3a]">{venue.address}</p>
           </div>
           <div className="scale-[0.92] origin-top-right opacity-88">
             <PriceBadge priceLevel={venue.priceLevel} />
           </div>
         </div>
         <div className="flex flex-wrap gap-2">
-          <div className="inline-flex items-center gap-1.5 rounded-full border border-muted bg-white px-2.5 py-1 text-caption text-text-secondary">
+          <div className="inline-flex items-center gap-1.5 rounded-full border border-[#d9c7b5] bg-white px-2.5 py-1 text-caption text-[#6a4a3a]">
             <StarIcon />
             {venue.rating.toFixed(1)}
           </div>
           {venue.tags.slice(0, 2).map((tag) => (
             <div
               key={tag}
-              className="rounded-full border border-muted bg-white px-2.5 py-1 text-caption text-text-secondary"
+              className="rounded-full border border-[#d9c7b5] bg-white px-2.5 py-1 text-caption text-[#6a4a3a]"
             >
               {tag}
             </div>
@@ -679,7 +679,7 @@ function PreviewVenueCard({
 
 function InfoPill({ children }: { readonly children: React.ReactNode }) {
   return (
-    <div className="inline-flex items-center gap-2 rounded-full border border-muted bg-white px-3 py-1.5 text-caption font-medium text-text-secondary">
+    <div className="inline-flex items-center gap-2 rounded-full border border-[#d9c7b5] bg-white px-3 py-1.5 text-caption font-medium text-[#6a4a3a]">
       {children}
     </div>
   );

--- a/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-deck-card.tsx
@@ -3,7 +3,6 @@
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
-import { Button } from "../../../../components/button";
 import { CategoryIcon } from "../../../../components/category-icon";
 import { PriceBadge } from "../../../../components/price-badge";
 import type { Category } from "../../../../lib/types/preference";
@@ -550,33 +549,30 @@ export function SwipeDeckCard({
           </div>
 
           <div className="grid grid-cols-2 gap-3">
-            <Button
-              variant="secondary"
+            <button
+              type="button"
               onClick={() => {
                 void triggerSwipe(false);
               }}
               disabled={submitting || Boolean(animatingSwipe)}
-              className="h-14 rounded-2xl border-[rgba(220,53,69,0.35)] bg-[rgba(220,53,69,0.08)] text-[#b22233] shadow-[0_12px_28px_rgba(220,53,69,0.15)] hover:bg-[rgba(220,53,69,0.14)]"
+              className="flex h-14 w-full items-center justify-center gap-2 rounded-2xl border border-[#dc3545] bg-[#dc3545] text-body font-semibold text-white transition-all duration-200 hover:bg-[#c42a3c] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80 disabled:cursor-not-allowed disabled:opacity-60"
               style={getActionButtonStyle("left", dragRatio, neutralReturnStrength)}
             >
-              <span className="flex items-center gap-2">
-                <PassIcon />
-                Pass
-              </span>
-            </Button>
-            <Button
+              <PassIcon />
+              Pass
+            </button>
+            <button
+              type="button"
               onClick={() => {
                 void triggerSwipe(true);
               }}
               disabled={submitting || Boolean(animatingSwipe)}
-              className="h-14 rounded-2xl border-transparent bg-[#10a37f] text-white shadow-[0_14px_30px_rgba(16,163,127,0.32)] hover:bg-[#0e8e6f]"
+              className="flex h-14 w-full items-center justify-center gap-2 rounded-2xl border border-[#10a37f] bg-[#10a37f] text-body font-semibold text-white transition-all duration-200 hover:bg-[#0e8e6f] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80 disabled:cursor-not-allowed disabled:opacity-60"
               style={getActionButtonStyle("right", dragRatio, neutralReturnStrength)}
             >
-              <span className="flex items-center gap-2">
-                <HeartIcon />
-                Like
-              </span>
-            </Button>
+              <HeartIcon />
+              Like
+            </button>
           </div>
         </div>
       </article>

--- a/web-service/src/app/plan/[id]/swipe/swipe-flow.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-flow.tsx
@@ -431,7 +431,7 @@ export function SwipeFlow({
               Swipe deck
             </p>
             <h1 className="mt-3 text-h1 font-semibold">Loading your venues</h1>
-            <p className="mt-3 text-body text-text-secondary">{statusMessage}</p>
+            <p className="mt-3 text-body text-white/70">{statusMessage}</p>
           </div>
         </div>
       </SwipeShell>
@@ -443,18 +443,18 @@ export function SwipeFlow({
 
     return (
       <SwipeShell creatorName={creatorName}>
-        <div className="mx-auto flex min-h-[60vh] max-w-xl flex-col items-center justify-center rounded-[2rem] border border-white/70 bg-white/85 px-6 py-10 text-center shadow-[0_20px_60px_rgba(45,42,38,0.12)] backdrop-blur-sm sm:px-8">
+        <div className="mx-auto flex min-h-[60vh] max-w-xl flex-col items-center justify-center rounded-[2rem] border border-white/15 bg-white/[0.06] px-6 py-10 text-center shadow-[0_30px_80px_rgba(0,0,0,0.45)] backdrop-blur-md sm:px-8">
           <LoadingOrnament variant={getWaitingLoaderVariant(waitingStage)} />
           <p className="mt-6 text-caption font-semibold uppercase tracking-[0.24em] text-secondary">
             {waitingCopy.eyebrow}
           </p>
-          <h1 className="mt-3 max-w-lg text-[clamp(2.2rem,6vw,3.5rem)] font-semibold leading-[0.96] tracking-[-0.04em] text-text">
+          <h1 className="mt-3 max-w-lg text-[clamp(2.2rem,6vw,3.5rem)] font-semibold leading-[0.96] tracking-[-0.04em] text-white">
             {waitingCopy.title}
           </h1>
-          <p className="mt-4 max-w-xl text-body text-text-secondary">
+          <p className="mt-4 max-w-xl text-body text-white/70">
             {waitingCopy.body}
           </p>
-          <p className="mt-3 max-w-lg text-body text-text-secondary">
+          <p className="mt-3 max-w-lg text-body text-white/70">
             {statusMessage}
           </p>
           <div className="mt-6 grid w-full max-w-lg gap-3 sm:grid-cols-2">
@@ -505,9 +505,9 @@ export function SwipeFlow({
   if (status === "error" || !currentVenue) {
     return (
       <SwipeShell creatorName={creatorName}>
-        <div className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center rounded-[2rem] border border-white/70 bg-white/85 px-6 py-10 text-center shadow-[0_20px_60px_rgba(45,42,38,0.12)] backdrop-blur-sm">
+        <div className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center rounded-[2rem] border border-white/15 bg-white/[0.06] px-6 py-10 text-center shadow-[0_30px_80px_rgba(0,0,0,0.45)] backdrop-blur-md">
           <h1 className="text-h1 font-semibold">Swipe demo unavailable</h1>
-          <p className="mt-3 text-body text-text-secondary">{statusMessage}</p>
+          <p className="mt-3 text-body text-white/70">{statusMessage}</p>
           <div className="mt-6 w-full max-w-sm">
             <Button variant="secondary" onClick={() => void bootstrap()}>
               Try again
@@ -522,7 +522,7 @@ export function SwipeFlow({
     <SwipeShell creatorName={creatorName}>
       <div className="mx-auto w-full max-w-md">
         <div className="relative mb-4 flex items-center justify-between gap-3">
-          <div className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/88 px-3 py-2 text-caption font-medium text-text-secondary shadow-sm">
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.08] px-3 py-2 text-caption font-medium text-white/70 shadow-sm">
             <span className="rounded-full bg-secondary-muted px-2.5 py-1 font-semibold text-secondary">
               {progressLabel}
             </span>
@@ -538,13 +538,13 @@ export function SwipeFlow({
             onClick={() => {
               setShowDeckInfo((current) => !current);
             }}
-            className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border border-white/70 bg-white/88 text-text-secondary shadow-sm transition-colors duration-200 hover:text-text"
+            className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border border-white/15 bg-white/[0.08] text-white/70 shadow-sm transition-colors duration-200 hover:text-text"
           >
             <InfoIcon />
           </button>
           {showDeckInfo ? (
-            <div className="absolute right-0 top-[calc(100%+0.5rem)] z-30 w-[min(18rem,calc(100vw-3rem))] rounded-[1.35rem] border border-white/70 bg-white/90 p-4 shadow-[0_18px_40px_rgba(45,42,38,0.12)] backdrop-blur-xl">
-              <p className="text-body text-text-secondary">
+            <div className="absolute right-0 top-[calc(100%+0.5rem)] z-30 w-[min(18rem,calc(100vw-3rem))] rounded-[1.35rem] border border-white/15 bg-white/[0.08] p-4 shadow-[0_24px_56px_rgba(0,0,0,0.45)] backdrop-blur-xl">
+              <p className="text-body text-white/70">
                 Drag right to like, drag left to pass. You can also use the buttons at the bottom of the card.
               </p>
             </div>
@@ -592,7 +592,7 @@ function SwipeShell({
   readonly creatorName: string;
 }) {
   return (
-    <main className="relative min-h-dvh overflow-hidden bg-bg px-6 pb-10 pt-8 text-text sm:px-8">
+    <main className="bg-shared-wine relative min-h-dvh overflow-hidden px-6 pb-10 pt-8 text-white sm:px-8">
       <div
         className="pointer-events-none absolute -left-20 top-12 h-72 w-72 rounded-full blur-3xl"
         style={{ background: "var(--color-primary-muted)" }}
@@ -607,7 +607,7 @@ function SwipeShell({
       <div className="mx-auto max-w-5xl">
         <div className="mb-8 flex items-center justify-between gap-4">
           <Logo />
-          <div className="rounded-full border border-white/70 bg-white/85 px-3 py-2 text-caption font-medium text-text-secondary shadow-sm">
+          <div className="rounded-full border border-white/15 bg-white/[0.06] px-3 py-2 text-caption font-medium text-white/70 backdrop-blur-sm">
             {creatorName}
             {"'"}s invite
           </div>
@@ -627,9 +627,9 @@ function WaitingCard({
   readonly body: string;
 }) {
   return (
-    <div className="rounded-[1.5rem] border border-muted bg-bg/75 px-4 py-4 text-left">
-      <h2 className="text-body font-semibold text-text">{title}</h2>
-      <p className="mt-2 text-body text-text-secondary">{body}</p>
+    <div className="rounded-[1.5rem] border border-white/10 bg-white/[0.04] px-4 py-4 text-left backdrop-blur-sm">
+      <h2 className="text-body font-semibold text-white">{title}</h2>
+      <p className="mt-2 text-body text-white/70">{body}</p>
     </div>
   );
 }

--- a/web-service/src/components/__tests__/button.test.tsx
+++ b/web-service/src/components/__tests__/button.test.tsx
@@ -6,7 +6,7 @@ describe("Button", () => {
   it("renders focus-visible and hover-safe motion classes", () => {
     const html = renderToStaticMarkup(<Button>Press me</Button>);
 
-    expect(html).toContain("focus-visible:outline-primary");
+    expect(html).toContain("focus-visible:outline-white/80");
     expect(html).toContain("motion-safe:hover:-translate-y-0.5");
     expect(html).not.toContain("active:scale-[0.98]");
   });

--- a/web-service/src/components/auth-sheet.tsx
+++ b/web-service/src/components/auth-sheet.tsx
@@ -83,8 +83,8 @@ export function AuthSheet({
               className="pointer-events-none absolute inset-0"
               style={{
                 background: [
-                  "radial-gradient(ellipse 90% 60% at 10% 0%,   rgba(224,116,104,0.28) 0%, transparent 55%)",
-                  "radial-gradient(ellipse 70% 80% at 90% 100%,  rgba(91,154,139,0.2)  0%, transparent 50%)",
+                  "radial-gradient(ellipse 90% 60% at 10% 0%,   rgba(208,61,106,0.35) 0%, transparent 55%)",
+                  "radial-gradient(ellipse 70% 80% at 90% 100%,  rgba(232,160,138,0.22)  0%, transparent 50%)",
                   "radial-gradient(ellipse 55% 45% at 60% 45%,   rgba(255,255,255,0.025) 0%, transparent 70%)",
                 ].join(","),
               }}
@@ -182,7 +182,7 @@ export function AuthSheet({
                     key={m}
                     type="button"
                     onClick={() => onModeChange(m)}
-                    className={`flex-1 cursor-pointer rounded-[0.65rem] px-3 py-2.5 text-[0.83rem] font-semibold transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#E07468] ${
+                    className={`flex-1 cursor-pointer rounded-[0.65rem] px-3 py-2.5 text-[0.83rem] font-semibold transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#d03d6a] ${
                       mode === m
                         ? "bg-white text-[#1A1410] shadow-[0_1px_6px_rgba(0,0,0,0.1)]"
                         : "text-[#8A827A] hover:text-[#1A1410]"
@@ -196,7 +196,7 @@ export function AuthSheet({
                 type="button"
                 onClick={onClose}
                 aria-label="Close account modal"
-                className="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-full border border-[#DDD8D1] bg-white text-[#8A827A] shadow-sm transition-all duration-200 hover:border-[#C8C0B5] hover:text-[#1A1410] motion-safe:hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#E07468]"
+                className="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-full border border-[#DDD8D1] bg-white text-[#8A827A] shadow-sm transition-all duration-200 hover:border-[#C8C0B5] hover:text-[#1A1410] motion-safe:hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#d03d6a]"
               >
                 <CloseIcon />
               </button>
@@ -248,7 +248,7 @@ export function AuthSheet({
                     onDraftChange({ ...draft, email: event.target.value })
                   }
                   placeholder="you@example.com"
-                  className="w-full rounded-[0.85rem] border border-[#DDD8D1] bg-white px-4 py-3 text-[0.9rem] text-[#1A1410] outline-none placeholder:text-[#C0B8AF] transition-[border-color,box-shadow] duration-200 focus:border-[#E07468] focus:shadow-[0_0_0_3px_rgba(224,116,104,0.15)]"
+                  className="w-full rounded-[0.85rem] border border-[#DDD8D1] bg-white px-4 py-3 text-[0.9rem] text-[#1A1410] outline-none placeholder:text-[#C0B8AF] transition-[border-color,box-shadow] duration-200 focus:border-[#d03d6a] focus:shadow-[0_0_0_3px_rgba(208,61,106,0.2)]"
                 />
               </label>
 
@@ -266,7 +266,7 @@ export function AuthSheet({
                   placeholder={
                     mode === "register" ? "At least 8 characters" : "Your password"
                   }
-                  className="w-full rounded-[0.85rem] border border-[#DDD8D1] bg-white px-4 py-3 text-[0.9rem] text-[#1A1410] outline-none placeholder:text-[#C0B8AF] transition-[border-color,box-shadow] duration-200 focus:border-[#E07468] focus:shadow-[0_0_0_3px_rgba(224,116,104,0.15)]"
+                  className="w-full rounded-[0.85rem] border border-[#DDD8D1] bg-white px-4 py-3 text-[0.9rem] text-[#1A1410] outline-none placeholder:text-[#C0B8AF] transition-[border-color,box-shadow] duration-200 focus:border-[#d03d6a] focus:shadow-[0_0_0_3px_rgba(208,61,106,0.2)]"
                 />
               </label>
 
@@ -315,7 +315,7 @@ type OAuthButtonProps = {
 
 function OAuthButton({ onClick, disabled, variant, icon, label }: OAuthButtonProps) {
   const base =
-    "flex h-[3.1rem] w-full cursor-pointer items-center justify-center gap-2.5 rounded-[0.85rem] px-4 text-[0.87rem] font-semibold transition-[transform,box-shadow,opacity] duration-200 motion-safe:hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#E07468] disabled:cursor-not-allowed disabled:opacity-50";
+    "flex h-[3.1rem] w-full cursor-pointer items-center justify-center gap-2.5 rounded-[0.85rem] px-4 text-[0.87rem] font-semibold transition-[transform,box-shadow,opacity] duration-200 motion-safe:hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#d03d6a] disabled:cursor-not-allowed disabled:opacity-50";
 
   const dark =
     "bg-[#0D0B09] text-white shadow-[0_2px_8px_rgba(0,0,0,0.22)] hover:shadow-[0_6px_22px_rgba(0,0,0,0.32)]";
@@ -357,7 +357,7 @@ function HeartDotIcon() {
     <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3 w-3" fill="none">
       <path
         d="M8 13.5S2 9.5 2 5.5a3 3 0 0 1 6-1.02A3 3 0 0 1 14 5.5c0 4-6 8-6 8z"
-        fill="rgba(224,116,104,0.7)"
+        fill="rgba(208,61,106,0.85)"
       />
     </svg>
   );

--- a/web-service/src/components/button.tsx
+++ b/web-service/src/components/button.tsx
@@ -2,7 +2,7 @@
 
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
-type ButtonVariant = "primary" | "secondary";
+type ButtonVariant = "primary" | "secondary" | "ghost";
 
 type ButtonProps = {
   readonly variant?: ButtonVariant;
@@ -12,27 +12,30 @@ type ButtonProps = {
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children">;
 
 const baseStyles =
-  "flex w-full items-center justify-center gap-2 rounded-2xl text-body font-semibold transition-all duration-200 h-14 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary";
+  "flex w-full items-center justify-center gap-2 rounded-2xl text-body font-semibold transition-all duration-200 h-14 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80";
 
 const variantStyles: Record<ButtonVariant, string> = {
+  // The hero CTA — white pill with raspberry ink and a hot-pink halo.
+  // Works on both the brown (Person A) and raspberry (Person B) canvases.
   primary:
-    "bg-primary text-white shadow-sm hover:bg-primary-hover hover:shadow-[0_14px_26px_rgba(224,116,104,0.24)] motion-safe:hover:-translate-y-0.5",
+    "bg-white text-[#4a1224] shadow-[0_18px_40px_rgba(255,61,127,0.35),_inset_0_1px_0_rgba(255,255,255,0.9)] motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-[0_22px_48px_rgba(255,61,127,0.5),_inset_0_1px_0_rgba(255,255,255,0.9)]",
+  // Secondary action on a dark canvas — translucent glass pill.
   secondary:
-    "bg-surface text-text border-[1.5px] border-muted hover:border-text-secondary hover:shadow-[0_12px_20px_rgba(45,42,38,0.08)] motion-safe:hover:-translate-y-0.5",
+    "bg-white/[0.08] text-white border border-white/20 backdrop-blur-sm hover:bg-white/[0.14] hover:border-white/40 motion-safe:hover:-translate-y-0.5",
+  // Quiet tertiary — for dismiss / skip style actions.
+  ghost:
+    "bg-transparent text-white/80 border border-white/10 hover:bg-white/[0.06] hover:text-white",
 };
 
 const disabledStyles =
-  "bg-muted text-text-secondary cursor-not-allowed shadow-none hover:bg-muted";
+  "bg-white/15 text-white/45 cursor-not-allowed shadow-none border-transparent";
 
 const loadingStyles =
-  "bg-primary/70 text-white/90 cursor-wait shadow-none hover:bg-primary/70";
+  "bg-white/70 text-[#4a1224]/70 cursor-wait shadow-none";
 
 /**
- * Shared button component with primary/secondary variants and
- * loading/disabled states.
- *
- * Sizing: full-width, 56px tall (h-14), 16px border-radius (rounded-2xl).
- * All interactive elements in the app use this for consistent touch targets.
+ * Shared button — hero CTA uses white pill + raspberry ink + hot-pink glow,
+ * works across the brown (Person A) and raspberry (Person B) canvases.
  */
 export function Button({
   variant = "primary",
@@ -72,10 +75,6 @@ export function Button({
   );
 }
 
-/**
- * A simple spinning circle for button loading states.
- * Uses CSS animation — no JS, no external library.
- */
 function LoadingSpinner() {
   return (
     <svg

--- a/web-service/src/components/history-card.tsx
+++ b/web-service/src/components/history-card.tsx
@@ -13,9 +13,9 @@ export function HistoryCard({ session }: HistoryCardProps) {
     session.matchedVenue?.address ?? "No match was saved from this round.";
 
   return (
-    <article className="overflow-hidden rounded-[1.75rem] border border-white/70 bg-white/90 shadow-[0_18px_40px_rgba(45,42,38,0.08)] transition-all duration-200 hover:shadow-[0_24px_48px_rgba(45,42,38,0.12)] motion-safe:hover:-translate-y-0.5">
+    <article className="overflow-hidden rounded-[1.75rem] border border-white/15 bg-white/[0.06] shadow-[0_24px_60px_rgba(0,0,0,0.35)] backdrop-blur-md transition-all duration-200 hover:border-white/25 hover:shadow-[0_28px_72px_rgba(0,0,0,0.5)] motion-safe:hover:-translate-y-0.5">
       <div className="grid gap-0 sm:grid-cols-[180px_1fr]">
-        <div className="relative min-h-[160px] bg-[linear-gradient(135deg,var(--color-secondary-muted),var(--color-primary-muted))]">
+        <div className="relative min-h-[160px] bg-[linear-gradient(135deg,rgba(208,61,106,0.35),rgba(138,90,74,0.35))]">
           {session.matchedVenue?.photoUrl ? (
             <Image
               src={session.matchedVenue.photoUrl}
@@ -35,22 +35,22 @@ export function HistoryCard({ session }: HistoryCardProps) {
         </div>
 
         <div className="flex flex-col gap-4 p-5">
-          <div className="flex flex-wrap items-center gap-2 text-caption text-text-secondary">
-            <span className="rounded-full border border-muted bg-bg px-3 py-1.5">
+          <div className="flex flex-wrap items-center gap-2 text-caption text-white/70">
+            <span className="rounded-full border border-white/15 bg-white/[0.04] px-3 py-1.5">
               {getHistoryRoleLabel(session.role)}
             </span>
-            <span className="rounded-full border border-muted bg-bg px-3 py-1.5 capitalize">
+            <span className="rounded-full border border-white/15 bg-white/[0.04] px-3 py-1.5 capitalize">
               {session.status}
             </span>
           </div>
 
           <div>
-            <h2 className="text-h2 font-semibold text-text">{title}</h2>
-            <p className="mt-2 text-body text-text-secondary">{body}</p>
+            <h2 className="text-h2 font-semibold text-white">{title}</h2>
+            <p className="mt-2 text-body text-white/70">{body}</p>
           </div>
 
           <div className="mt-auto flex items-center justify-between gap-3">
-            <p className="text-caption text-text-secondary">
+            <p className="text-caption text-white/60">
               {new Date(session.createdAt).toLocaleDateString("en-US", {
                 month: "long",
                 day: "numeric",
@@ -63,7 +63,7 @@ export function HistoryCard({ session }: HistoryCardProps) {
                   ? `/plan/${session.sessionId}/results`
                   : `/plan/${session.sessionId}`
               }
-              className="cursor-pointer rounded-full border border-muted bg-bg px-4 py-2 text-caption font-semibold text-text transition-colors duration-200 hover:border-text-secondary hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              className="cursor-pointer rounded-full border border-white/20 bg-white/[0.06] px-4 py-2 text-caption font-semibold text-white transition-colors duration-200 hover:border-white/40 hover:bg-white/[0.12] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
             >
               View result
             </Link>

--- a/web-service/src/components/loading-ornament.tsx
+++ b/web-service/src/components/loading-ornament.tsx
@@ -31,31 +31,34 @@ export function LoadingOrnament({
   return <VenueGenerationLoader />;
 }
 
+// Role tones — raspberry (hot) and warm terracotta (bridges with brown).
+const RASPBERRY_SOFT = "rgba(255,61,127,0.32)";
+const WARM_SOFT = "rgba(232,160,138,0.22)";
+
 function VenueGenerationLoader() {
   return (
     <div className="relative flex h-44 items-center justify-center" aria-hidden="true">
       <div
-        className="absolute inset-x-8 top-10 h-24 rounded-[2rem] opacity-70 blur-2xl"
+        className="absolute inset-x-8 top-10 h-24 rounded-[2rem] opacity-80 blur-2xl"
         style={{
-          background:
-            "linear-gradient(135deg, rgba(255,126,107,0.2), rgba(120,214,201,0.16))",
+          background: `linear-gradient(135deg, ${RASPBERRY_SOFT}, ${WARM_SOFT})`,
         }}
       />
       <ShortlistCard
         className="-translate-x-10 translate-y-4 motion-safe:animate-[shortlistCardLeft_2.8s_ease-in-out_infinite] motion-reduce:animate-none"
-        accent="var(--color-primary-muted)"
+        accent={RASPBERRY_SOFT}
         title="Fair commute"
-        tone="coral"
+        tone="raspberry"
       />
       <ShortlistCard
         className="z-10 motion-safe:animate-[shortlistCardCenter_2.8s_ease-in-out_infinite] motion-reduce:animate-none"
-        accent="var(--color-secondary-muted)"
+        accent={WARM_SOFT}
         title="Good vibe"
-        tone="teal"
+        tone="warm"
       />
       <ShortlistCard
         className="translate-x-10 translate-y-4 motion-safe:animate-[shortlistCardRight_2.8s_ease-in-out_infinite] motion-reduce:animate-none"
-        accent="rgba(255,255,255,0.92)"
+        accent="rgba(255,255,255,0.85)"
         title="Top pick"
         tone="neutral"
       />
@@ -81,25 +84,24 @@ function DemoDeckLoader() {
   return (
     <div className="relative flex h-44 items-center justify-center" aria-hidden="true">
       <div
-        className="absolute inset-x-8 top-8 h-28 rounded-[2rem] opacity-70 blur-2xl"
+        className="absolute inset-x-8 top-8 h-28 rounded-[2rem] opacity-80 blur-2xl"
         style={{
-          background:
-            "linear-gradient(135deg, rgba(255,126,107,0.22), rgba(120,214,201,0.18))",
+          background: `linear-gradient(135deg, ${RASPBERRY_SOFT}, ${WARM_SOFT})`,
         }}
       />
       <DemoCard
         className="-rotate-12 motion-safe:animate-[demoCardLeft_2.6s_ease-in-out_infinite] motion-reduce:animate-none"
-        accent="var(--color-primary-muted)"
+        accent={RASPBERRY_SOFT}
         label="Food"
       />
       <DemoCard
         className="z-10 motion-safe:animate-[demoCardCenter_2.6s_ease-in-out_infinite] motion-reduce:animate-none"
-        accent="var(--color-secondary-muted)"
+        accent={WARM_SOFT}
         label="Drinks"
       />
       <DemoCard
         className="rotate-12 motion-safe:animate-[demoCardRight_2.6s_ease-in-out_infinite] motion-reduce:animate-none"
-        accent="rgba(255,255,255,0.88)"
+        accent="rgba(255,255,255,0.82)"
         label="Activity"
       />
       <style jsx>{`
@@ -124,20 +126,23 @@ function PartnerPreferencesLoader() {
   return (
     <div className="relative flex h-40 w-40 items-center justify-center" aria-hidden="true">
       <div
-        className="absolute inset-8 rounded-full opacity-75 blur-2xl"
+        className="absolute inset-8 rounded-full opacity-80 blur-2xl"
         style={{
           background:
-            "radial-gradient(circle, rgba(255,126,107,0.25) 0%, rgba(255,126,107,0.06) 70%, transparent 100%)",
+            "radial-gradient(circle, rgba(255,61,127,0.38) 0%, rgba(255,61,127,0.08) 70%, transparent 100%)",
         }}
       />
-      <div className="absolute bottom-8 left-11 flex h-9 w-9 items-center justify-center rounded-full bg-white/92 text-primary shadow-[0_16px_30px_rgba(45,42,38,0.12)] motion-safe:animate-[floatHeart_2.4s_ease-in-out_infinite] motion-reduce:animate-none">
+      <div className="absolute bottom-8 left-11 flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-[#8a2346] shadow-[0_16px_30px_rgba(0,0,0,0.4)] motion-safe:animate-[floatHeart_2.4s_ease-in-out_infinite] motion-reduce:animate-none">
         <HeartIcon className="h-4 w-4" />
       </div>
-      <div className="absolute bottom-12 right-10 flex h-7 w-7 items-center justify-center rounded-full bg-white/88 text-secondary shadow-[0_14px_24px_rgba(45,42,38,0.1)] motion-safe:animate-[floatDot_2s_ease-in-out_infinite] motion-reduce:animate-none">
-        <div className="h-2.5 w-2.5 rounded-full bg-secondary" />
+      <div className="absolute bottom-12 right-10 flex h-7 w-7 items-center justify-center rounded-full bg-white/85 text-[#4a302a] shadow-[0_14px_24px_rgba(0,0,0,0.35)] motion-safe:animate-[floatDot_2s_ease-in-out_infinite] motion-reduce:animate-none">
+        <div className="h-2.5 w-2.5 rounded-full bg-[#8a5a4a]" />
       </div>
-      <div className="absolute inset-[2.6rem] flex items-center justify-center rounded-full bg-white/92 shadow-[0_18px_34px_rgba(45,42,38,0.12)]">
-        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary-muted text-primary motion-safe:animate-pulse motion-reduce:animate-none">
+      <div className="absolute inset-[2.6rem] flex items-center justify-center rounded-full bg-white/90 shadow-[0_18px_34px_rgba(0,0,0,0.4)]">
+        <div
+          className="flex h-14 w-14 items-center justify-center rounded-full text-[#8a2346] motion-safe:animate-pulse motion-reduce:animate-none"
+          style={{ background: RASPBERRY_SOFT }}
+        >
           <HeartIcon className="h-6 w-6" />
         </div>
       </div>
@@ -159,14 +164,17 @@ function PartnerRoundLoader() {
   return (
     <div className="relative flex h-40 w-40 items-center justify-center" aria-hidden="true">
       <div
-        className="absolute inset-10 rounded-full opacity-75 blur-2xl"
+        className="absolute inset-10 rounded-full opacity-80 blur-2xl"
         style={{
           background:
-            "radial-gradient(circle, rgba(255,126,107,0.22) 0%, rgba(120,214,201,0.08) 68%, transparent 100%)",
+            "radial-gradient(circle, rgba(255,61,127,0.32) 0%, rgba(232,160,138,0.1) 68%, transparent 100%)",
         }}
       />
-      <div className="absolute inset-[2.55rem] flex items-center justify-center rounded-full bg-white/92 shadow-[0_18px_38px_rgba(45,42,38,0.14)]">
-        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary-muted text-primary">
+      <div className="absolute inset-[2.55rem] flex items-center justify-center rounded-full bg-white/90 shadow-[0_18px_38px_rgba(0,0,0,0.42)]">
+        <div
+          className="flex h-14 w-14 items-center justify-center rounded-full text-[#8a2346]"
+          style={{ background: RASPBERRY_SOFT }}
+        >
           <HeartIcon className="h-6 w-6" />
         </div>
       </div>
@@ -174,8 +182,8 @@ function PartnerRoundLoader() {
         className="absolute inset-0 motion-safe:animate-spin motion-reduce:animate-none"
         style={{ animationDuration: "9s" }}
       >
-        <div className="absolute left-1/2 top-1 h-7 w-7 -translate-x-1/2 rounded-full bg-white/92 shadow-[0_14px_28px_rgba(45,42,38,0.12)]">
-          <div className="flex h-full items-center justify-center text-primary">
+        <div className="absolute left-1/2 top-1 h-7 w-7 -translate-x-1/2 rounded-full bg-white/90 shadow-[0_14px_28px_rgba(0,0,0,0.4)]">
+          <div className="flex h-full items-center justify-center text-[#8a2346]">
             <HeartIcon className="h-3.5 w-3.5" />
           </div>
         </div>
@@ -184,7 +192,9 @@ function PartnerRoundLoader() {
         className="absolute inset-[0.85rem] motion-safe:animate-spin motion-reduce:animate-none"
         style={{ animationDirection: "reverse", animationDuration: "6.3s" }}
       >
-        <div className="absolute right-0 top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-secondary shadow-[0_0_0_8px_rgba(120,214,201,0.14)]" />
+        <div
+          className="absolute right-0 top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-[#e8a08a] shadow-[0_0_0_8px_rgba(232,160,138,0.18)]"
+        />
       </div>
     </div>
   );
@@ -194,17 +204,17 @@ function SessionCheckLoader() {
   return (
     <div className="relative flex h-36 w-36 items-center justify-center" aria-hidden="true">
       <div
-        className="absolute inset-6 rounded-full opacity-70 blur-2xl"
+        className="absolute inset-6 rounded-full opacity-75 blur-2xl"
         style={{
           background:
-            "radial-gradient(circle, rgba(120,214,201,0.24) 0%, rgba(120,214,201,0.06) 72%, transparent 100%)",
+            "radial-gradient(circle, rgba(255,61,127,0.32) 0%, rgba(255,61,127,0.06) 72%, transparent 100%)",
         }}
       />
       <div className="flex items-end gap-2">
         {[0, 1, 2].map((index) => (
           <div
             key={index}
-            className="w-3 rounded-full bg-secondary/80 motion-safe:animate-[signalRise_1.4s_ease-in-out_infinite] motion-reduce:animate-none"
+            className="w-3 rounded-full bg-white/80 motion-safe:animate-[signalRise_1.4s_ease-in-out_infinite] motion-reduce:animate-none"
             style={{
               height: `${26 + index * 10}px`,
               animationDelay: `${index * 0.16}s`,
@@ -233,16 +243,16 @@ function DemoCard({
 }) {
   return (
     <div
-      className={`absolute flex h-32 w-24 flex-col justify-between rounded-[1.6rem] border border-white/70 bg-white/92 p-3 shadow-[0_22px_40px_rgba(45,42,38,0.12)] ${className}`}
+      className={`absolute flex h-32 w-24 flex-col justify-between rounded-[1.6rem] border border-white/20 bg-white/[0.08] p-3 shadow-[0_22px_40px_rgba(0,0,0,0.4)] backdrop-blur-sm ${className}`}
     >
       <div
         className="h-14 rounded-[1rem]"
-        style={{ background: `linear-gradient(135deg, ${accent}, rgba(255,255,255,0.35))` }}
+        style={{ background: `linear-gradient(135deg, ${accent}, rgba(255,255,255,0.25))` }}
       />
       <div className="space-y-2">
-        <div className="h-2 w-12 rounded-full bg-text/10" />
-        <div className="h-2 w-16 rounded-full bg-text/10" />
-        <p className="text-[0.62rem] font-semibold uppercase tracking-[0.14em] text-text-secondary">
+        <div className="h-2 w-12 rounded-full bg-white/25" />
+        <div className="h-2 w-16 rounded-full bg-white/25" />
+        <p className="text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-white/70">
           {label}
         </p>
       </div>
@@ -259,28 +269,28 @@ function ShortlistCard({
   readonly className: string;
   readonly accent: string;
   readonly title: string;
-  readonly tone: "coral" | "teal" | "neutral";
+  readonly tone: "raspberry" | "warm" | "neutral";
 }) {
   const pillClassName =
-    tone === "coral"
-      ? "bg-primary-muted text-primary"
-      : tone === "teal"
-        ? "bg-secondary-muted text-secondary"
-        : "bg-bg text-text-secondary";
+    tone === "raspberry"
+      ? "bg-white/15 text-white"
+      : tone === "warm"
+        ? "bg-white/12 text-[#f5d5c5]"
+        : "bg-white/10 text-white/80";
 
   return (
     <div
-      className={`absolute flex h-28 w-28 flex-col justify-between rounded-[1.6rem] border border-white/70 bg-white/94 p-3 shadow-[0_22px_40px_rgba(45,42,38,0.12)] ${className}`}
+      className={`absolute flex h-28 w-28 flex-col justify-between rounded-[1.6rem] border border-white/20 bg-white/[0.08] p-3 shadow-[0_22px_40px_rgba(0,0,0,0.4)] backdrop-blur-sm ${className}`}
     >
       <div
         className="h-11 rounded-[1rem]"
-        style={{ background: `linear-gradient(135deg, ${accent}, rgba(255,255,255,0.35))` }}
+        style={{ background: `linear-gradient(135deg, ${accent}, rgba(255,255,255,0.22))` }}
       />
       <div className="space-y-2">
         <div className={`inline-flex rounded-full px-2 py-1 text-[0.58rem] font-semibold uppercase tracking-[0.12em] ${pillClassName}`}>
           {title}
         </div>
-        <div className="h-2 w-14 rounded-full bg-text/10" />
+        <div className="h-2 w-14 rounded-full bg-white/25" />
       </div>
     </div>
   );
@@ -293,3 +303,4 @@ function HeartIcon({ className }: { readonly className: string }) {
     </svg>
   );
 }
+

--- a/web-service/src/components/loading-screen.tsx
+++ b/web-service/src/components/loading-screen.tsx
@@ -17,9 +17,9 @@ const CYCLE_INTERVAL_MS = 2400;
 /**
  * Screen 4 — Loading.
  *
- * Displayed while the API processes preferences and generates venue suggestions.
- * Two animated concentric rings (coral outer, teal inner) + cycling subtitle text
- * create the feeling of real work happening, not just a spinner.
+ * Sits on the raspberry canvas (Person B's world) so the transition from
+ * the invitation landing feels continuous. A translucent glass card holds
+ * the ornament + cycling subtitle.
  */
 export function LoadingScreen({ demoMode = false }: { readonly demoMode?: boolean }) {
   const [subtitleIndex, setSubtitleIndex] = useState(0);
@@ -33,29 +33,34 @@ export function LoadingScreen({ demoMode = false }: { readonly demoMode?: boolea
   }, []);
 
   return (
-    <div className="relative flex min-h-dvh flex-col justify-center overflow-hidden bg-bg px-6">
+    <div className="bg-person-b relative flex min-h-dvh flex-col justify-center overflow-hidden px-6 text-white">
       <div
-        className="pointer-events-none absolute left-1/2 top-1/3 h-72 w-72 -translate-x-1/2 rounded-full opacity-20 blur-3xl"
-        style={{ background: "var(--color-primary)" }}
+        className="pointer-events-none absolute left-1/2 top-1/3 h-72 w-72 -translate-x-1/2 rounded-full opacity-40 blur-3xl"
+        style={{ background: "var(--accent-hot)" }}
         aria-hidden="true"
       />
-      <div className="absolute top-10 left-6">
+      <div
+        className="pointer-events-none absolute -bottom-20 left-0 h-80 w-80 rounded-full opacity-30 blur-3xl"
+        style={{ background: "var(--raspberry-600)" }}
+        aria-hidden="true"
+      />
+      <div className="absolute top-10 left-6 text-white">
         <Logo />
       </div>
 
-      <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-10 rounded-[2rem] border border-white/70 bg-white/80 px-8 py-10 text-center shadow-[0_24px_80px_rgba(45,42,38,0.12)] backdrop-blur-sm">
+      <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-10 rounded-[2rem] border border-white/15 bg-white/[0.06] px-8 py-10 text-center shadow-[0_30px_80px_rgba(0,0,0,0.35)] backdrop-blur-md">
         <LoadingOrnament variant={demoMode ? "demo-deck" : "venue"} />
 
         <div className="max-w-2xl">
-          <p className="text-caption font-semibold uppercase tracking-[0.24em] text-secondary">
+          <p className="text-caption font-semibold uppercase tracking-[0.28em] text-white/70">
             Venue generation
           </p>
-          <h1 className="mt-3 text-[clamp(2.5rem,8vw,4rem)] font-semibold leading-[0.95] tracking-[-0.05em] text-text">
+          <h1 className="mt-3 text-[clamp(2.5rem,8vw,4rem)] font-semibold leading-[0.95] tracking-[-0.05em] text-white">
             {demoMode ? "Building your demo deck" : "Finding your spots"}
           </h1>
           <p
             key={subtitleIndex}
-            className="mt-4 text-body text-text-secondary"
+            className="mt-4 text-body text-white/70"
             style={{ animation: "fadeIn 0.4s ease-in" }}
           >
             {demoMode
@@ -82,11 +87,11 @@ function LoadingCard({
   readonly body: string;
 }) {
   return (
-    <div className="rounded-[1.5rem] border border-muted bg-bg/75 px-4 py-4">
-      <p className="text-caption font-semibold uppercase tracking-[0.18em] text-secondary">
+    <div className="rounded-[1.5rem] border border-white/10 bg-white/[0.04] px-4 py-4 text-left backdrop-blur-sm">
+      <p className="text-caption font-semibold uppercase tracking-[0.24em] text-white/65">
         {label}
       </p>
-      <p className="mt-2 text-body text-text-secondary">{body}</p>
+      <p className="mt-2 text-body text-white/85">{body}</p>
     </div>
   );
 }

--- a/web-service/src/lib/services/__tests__/venue-why-picked.test.ts
+++ b/web-service/src/lib/services/__tests__/venue-why-picked.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { buildWhyPicked } from "../venue-why-picked";
+import type { CuratedVenueCandidate } from "../../types/venue";
+
+function baseCandidate(
+  overrides: Partial<CuratedVenueCandidate> = {},
+): CuratedVenueCandidate {
+  return {
+    placeId: "p1",
+    name: "Test Venue",
+    address: "1 Main St",
+    location: { lat: 0, lng: 0, label: "Test Venue" },
+    types: ["restaurant"],
+    priceLevel: 2,
+    rating: 4.4,
+    reviewCount: 1200,
+    photoReferences: [],
+    photoReference: null,
+    photoUrls: [],
+    category: "RESTAURANT",
+    score: {
+      categoryOverlap: 1,
+      distanceToMidpoint: 1,
+      firstDateSuitability: 1,
+      qualitySignal: 1,
+      timeOfDayFit: 1,
+      composite: 1,
+    },
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe("buildWhyPicked", () => {
+  it("returns a <=140-char blurb citing rating and distance", () => {
+    const why = buildWhyPicked(baseCandidate(), 800);
+    expect(why).toBeDefined();
+    expect(why!.length).toBeLessThanOrEqual(140);
+    expect(why).toContain("4.4");
+    expect(why).toContain("mi");
+  });
+
+  it("returns undefined when there are no useful signals", () => {
+    const why = buildWhyPicked(
+      baseCandidate({ rating: 3.2, reviewCount: 3, editorialSummary: undefined }),
+      undefined,
+    );
+    expect(why).toBeUndefined();
+  });
+
+  it("incorporates editorial summary when present", () => {
+    const why = buildWhyPicked(
+      baseCandidate({ editorialSummary: "Cozy wine bar with small plates" }),
+      500,
+    );
+    expect(why).toBeDefined();
+    expect(why!.length).toBeLessThanOrEqual(140);
+  });
+});

--- a/web-service/src/lib/services/ai-curation-service.ts
+++ b/web-service/src/lib/services/ai-curation-service.ts
@@ -136,12 +136,42 @@ function timeOfDayFit(category: Category, round: number): number {
 }
 
 function buildFallbackTags(category: Category, candidate: PlaceCandidate): readonly string[] {
+  // First tag is the internal `unscored` marker (used by tests and the AI
+  // pipeline to detect a deterministic fallback); remaining tags are the
+  // excitement-driven labels rendered on the swipe card.
   return [
     "unscored",
-    ...(candidate.rating >= 4.5 ? ["top-rated"] : []),
-    ...(candidate.reviewCount >= 250 ? ["well-reviewed"] : []),
-    category.toLowerCase(),
+    ...pickRatingFlair(candidate.rating),
+    ...pickBuzzFlair(candidate.reviewCount),
+    pickCategoryFlair(category),
   ];
+}
+
+function pickRatingFlair(rating: number): readonly string[] {
+  if (rating >= 4.7) return ["Crowd favorite"];
+  if (rating >= 4.4) return ["Raves in"];
+  if (rating >= 4.1) return ["Well-loved"];
+  return [];
+}
+
+function pickBuzzFlair(reviewCount: number): readonly string[] {
+  if (reviewCount >= 500) return ["Legendary spot"];
+  if (reviewCount >= 250) return ["Locals' pick"];
+  if (reviewCount >= 80) return ["Neighborhood gem"];
+  return ["Under the radar"];
+}
+
+function pickCategoryFlair(category: Category): string {
+  switch (category) {
+    case "RESTAURANT":
+      return "Dinner-worthy";
+    case "BAR":
+      return "Sip & linger";
+    case "ACTIVITY":
+      return "Playful pick";
+    case "EVENT":
+      return "Main event";
+  }
 }
 
 export function buildDeterministicRanking(

--- a/web-service/src/lib/services/places-api-client.ts
+++ b/web-service/src/lib/services/places-api-client.ts
@@ -23,6 +23,10 @@ const FIELD_MASK = [
   "places.rating",
   "places.userRatingCount",
   "places.photos",
+  "places.editorialSummary",
+  "places.regularOpeningHours",
+  "places.currentOpeningHours",
+  "places.websiteUri",
 ].join(",");
 
 export function getGooglePlacesReadiness(): {
@@ -178,6 +182,11 @@ export function categoriesToGoogleTypes(categories: readonly Category[]): readon
 // Response types (Google Places API v1 shape)
 // ---------------------------------------------------------------------------
 
+type GoogleOpeningHours = {
+  readonly openNow?: boolean;
+  readonly weekdayDescriptions?: readonly string[];
+};
+
 type GooglePlace = {
   readonly id: string;
   readonly displayName: { readonly text: string };
@@ -188,6 +197,10 @@ type GooglePlace = {
   readonly rating?: number;
   readonly userRatingCount?: number;
   readonly photos?: readonly { readonly name: string }[];
+  readonly editorialSummary?: { readonly text?: string };
+  readonly regularOpeningHours?: GoogleOpeningHours;
+  readonly currentOpeningHours?: GoogleOpeningHours;
+  readonly websiteUri?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -261,9 +274,19 @@ export async function searchNearby(
   const data = await response.json();
   const places: readonly GooglePlace[] = data.places ?? [];
 
-  const candidates = places.map((place) => {
+  const candidates: readonly PlaceCandidate[] = places.map((place) => {
     const photoReferences = (place.photos ?? []).map((photo) => photo.name);
     const priceLevel = parsePriceLevel(place.priceLevel);
+    const editorialSummary = place.editorialSummary?.text?.trim();
+    const hoursSource = place.currentOpeningHours ?? place.regularOpeningHours;
+    const openingHours =
+      hoursSource && typeof hoursSource.openNow === "boolean"
+        ? {
+            openNow: hoursSource.openNow,
+            weekdayText: hoursSource.weekdayDescriptions ?? [],
+          }
+        : undefined;
+    const website = place.websiteUri?.trim();
 
     return {
       placeId: place.id,
@@ -281,6 +304,9 @@ export async function searchNearby(
       photoReferences,
       photoReference: photoReferences[0] ?? null,
       photoUrls: buildGooglePlacePhotoUrls(photoReferences),
+      ...(editorialSummary ? { editorialSummary } : {}),
+      ...(openingHours ? { openingHours } : {}),
+      ...(website ? { website } : {}),
     };
   });
 

--- a/web-service/src/lib/services/venue-generation-service.ts
+++ b/web-service/src/lib/services/venue-generation-service.ts
@@ -6,7 +6,8 @@ import type {
 import type { BudgetLevel, Category, Preference } from "../types/preference";
 import { toVenue, type Venue, type VenueRow } from "../types/venue";
 import { getBothPreferences } from "./preference-service";
-import { calculateMidpoint } from "./midpoint-calculator";
+import { calculateMidpoint, distanceBetween } from "./midpoint-calculator";
+import { buildWhyPicked } from "./venue-why-picked";
 import { searchNearbyWithCache } from "./places-api-cached";
 import {
   buildGooglePlacePhotoUrl,
@@ -100,6 +101,14 @@ type InsertVenueRow = {
   readonly score_time_of_day_fit: number;
   readonly generation_batch_id: string;
   readonly surfaced_cycle: number;
+  readonly editorial_summary: string | null;
+  readonly user_rating_count: number | null;
+  readonly opening_hours:
+    | { readonly open_now: boolean; readonly weekday_text: readonly string[] }
+    | null;
+  readonly distance_meters: number | null;
+  readonly website: string | null;
+  readonly why_picked: string | null;
 };
 
 async function insertVenues(rows: readonly InsertVenueRow[]): Promise<void> {
@@ -247,6 +256,11 @@ export async function generateVenues(sessionId: string): Promise<readonly Venue[
       const roundPicks = curated.slice(0, 4);
 
       roundPicks.forEach((venue, index) => {
+        const distanceMeters = Math.round(
+          distanceBetween(midpoint, venue.location),
+        );
+        const whyPicked =
+          venue.whyPicked ?? buildWhyPicked(venue, distanceMeters);
         selectedRows.push({
           session_id: sessionId,
           place_id: venue.placeId,
@@ -269,6 +283,18 @@ export async function generateVenues(sessionId: string): Promise<readonly Venue[
           score_time_of_day_fit: venue.score.timeOfDayFit,
           generation_batch_id: generationBatchId,
           surfaced_cycle: 1,
+          editorial_summary: venue.editorialSummary ?? null,
+          user_rating_count:
+            typeof venue.reviewCount === "number" ? venue.reviewCount : null,
+          opening_hours: venue.openingHours
+            ? {
+                open_now: venue.openingHours.openNow,
+                weekday_text: venue.openingHours.weekdayText,
+              }
+            : null,
+          distance_meters: distanceMeters,
+          website: venue.website ?? null,
+          why_picked: whyPicked ?? null,
         });
       });
 

--- a/web-service/src/lib/services/venue-why-picked.ts
+++ b/web-service/src/lib/services/venue-why-picked.ts
@@ -1,0 +1,71 @@
+import type { Category } from "../types/preference";
+import type { CuratedVenueCandidate } from "../types/venue";
+
+const MAX_LENGTH = 140;
+
+const CATEGORY_HOOK: Record<Category, string> = {
+  RESTAURANT: "a great sit-down spot",
+  BAR: "a relaxed spot to share drinks",
+  ACTIVITY: "a fun shared activity",
+  EVENT: "a memorable shared event",
+};
+
+/**
+ * Builds a short (<=140 char) "why we picked this" blurb for a venue.
+ *
+ * Deterministic and explanatory — it references the venue's own strengths
+ * (rating, review volume, distance, editorial tagline) rather than generic
+ * copy. Returns `undefined` if we have nothing useful to say.
+ */
+export function buildWhyPicked(
+  candidate: CuratedVenueCandidate,
+  distanceMeters: number | undefined,
+): string | undefined {
+  const hook = CATEGORY_HOOK[candidate.category];
+  const signals: string[] = [];
+
+  if (candidate.rating >= 4.3 && candidate.reviewCount >= 50) {
+    signals.push(
+      `rated ${candidate.rating.toFixed(1)} across ${formatCount(candidate.reviewCount)} reviews`,
+    );
+  } else if (candidate.rating >= 4.0) {
+    signals.push(`rated ${candidate.rating.toFixed(1)}`);
+  }
+
+  if (typeof distanceMeters === "number" && distanceMeters > 0) {
+    signals.push(`close to your midpoint (${formatMiles(distanceMeters)})`);
+  }
+
+  if (candidate.editorialSummary) {
+    signals.push(candidate.editorialSummary.trim().replace(/\.$/, ""));
+  }
+
+  if (signals.length === 0) {
+    return undefined;
+  }
+
+  const blurb = `Picked as ${hook} — ${signals.slice(0, 2).join(", ")}.`;
+  if (blurb.length <= MAX_LENGTH) {
+    return blurb;
+  }
+
+  const trimmed = blurb.slice(0, MAX_LENGTH - 1).trimEnd();
+  return `${trimmed.replace(/[,.;:]$/, "")}…`;
+}
+
+function formatCount(count: number): string {
+  if (count >= 1_000) {
+    const thousands = count / 1_000;
+    const rounded = thousands >= 10 ? Math.round(thousands) : Math.round(thousands * 10) / 10;
+    return `${rounded}k`;
+  }
+  return String(count);
+}
+
+function formatMiles(meters: number): string {
+  const miles = meters / 1609.344;
+  if (miles < 0.1) {
+    return "<0.1 mi";
+  }
+  return `${miles.toFixed(1)} mi`;
+}

--- a/web-service/src/lib/types/__tests__/venue-enriched.test.ts
+++ b/web-service/src/lib/types/__tests__/venue-enriched.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { toVenue, type VenueRow } from "../venue";
+
+function baseRow(overrides: Partial<VenueRow> = {}): VenueRow {
+  return {
+    id: "v1",
+    session_id: "s1",
+    place_id: "p1",
+    name: "Test",
+    category: "RESTAURANT",
+    address: "1 Main",
+    lat: 0,
+    lng: 0,
+    price_level: 2,
+    rating: 4.2,
+    photo_url: null,
+    photo_urls: [],
+    tags: [],
+    round: 1,
+    position: 1,
+    score_category_overlap: 1,
+    score_distance_to_midpoint: 1,
+    score_first_date_suitability: 1,
+    score_quality_signal: 1,
+    score_time_of_day_fit: 1,
+    ...overrides,
+  };
+}
+
+describe("toVenue — enriched fields", () => {
+  it("maps editorial summary, review count, distance, website, and why_picked", () => {
+    const venue = toVenue(
+      baseRow({
+        editorial_summary: "A cozy spot",
+        user_rating_count: 1234,
+        distance_meters: 820,
+        website: "https://example.com",
+        why_picked: "Picked as a great sit-down spot — rated 4.4, 0.5 mi.",
+      }),
+    );
+    expect(venue.editorialSummary).toBe("A cozy spot");
+    expect(venue.userRatingCount).toBe(1234);
+    expect(venue.distanceMeters).toBe(820);
+    expect(venue.website).toBe("https://example.com");
+    expect(venue.whyPicked).toContain("Picked as");
+  });
+
+  it("maps opening_hours from snake_case JSONB", () => {
+    const venue = toVenue(
+      baseRow({
+        opening_hours: {
+          open_now: true,
+          weekday_text: ["Mon: 9-5", "Tue: 9-5"],
+        },
+      }),
+    );
+    expect(venue.openingHours?.openNow).toBe(true);
+    expect(venue.openingHours?.weekdayText).toHaveLength(2);
+  });
+
+  it("omits openingHours when openNow is not a boolean", () => {
+    const venue = toVenue(baseRow({ opening_hours: { weekday_text: [] } }));
+    expect(venue.openingHours).toBeUndefined();
+  });
+
+  it("omits optional fields when missing", () => {
+    const venue = toVenue(baseRow());
+    expect(venue.editorialSummary).toBeUndefined();
+    expect(venue.userRatingCount).toBeUndefined();
+    expect(venue.distanceMeters).toBeUndefined();
+    expect(venue.website).toBeUndefined();
+    expect(venue.whyPicked).toBeUndefined();
+    expect(venue.openingHours).toBeUndefined();
+  });
+});

--- a/web-service/src/lib/types/venue.ts
+++ b/web-service/src/lib/types/venue.ts
@@ -74,6 +74,11 @@ export function computeVenueComposite(
  * **rating, priceLevel:** From Google Places. Rating is 0–5 (decimal).
  *   priceLevel is 1–4 ($ to $$$$).
  */
+export type VenueOpeningHours = {
+  readonly openNow: boolean;
+  readonly weekdayText: readonly string[];
+};
+
 export type Venue = {
   readonly id: string;
   readonly sessionId: string;
@@ -91,6 +96,12 @@ export type Venue = {
   readonly round: number;
   readonly position: number;
   readonly score: VenueScore;
+  readonly editorialSummary?: string;
+  readonly userRatingCount?: number;
+  readonly openingHours?: VenueOpeningHours;
+  readonly distanceMeters?: number;
+  readonly website?: string;
+  readonly whyPicked?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -123,7 +134,30 @@ export type VenueRow = {
   readonly score_first_date_suitability: number;
   readonly score_quality_signal: number;
   readonly score_time_of_day_fit: number;
+  readonly editorial_summary?: string | null;
+  readonly user_rating_count?: number | null;
+  readonly opening_hours?: VenueOpeningHoursRow | null;
+  readonly distance_meters?: number | null;
+  readonly website?: string | null;
+  readonly why_picked?: string | null;
 };
+
+export type VenueOpeningHoursRow = {
+  readonly open_now?: boolean;
+  readonly openNow?: boolean;
+  readonly weekday_text?: readonly string[];
+  readonly weekdayText?: readonly string[];
+};
+
+function toOpeningHours(
+  raw: VenueOpeningHoursRow | null | undefined,
+): VenueOpeningHours | undefined {
+  if (!raw) return undefined;
+  const openNow = raw.openNow ?? raw.open_now;
+  const weekdayText = raw.weekdayText ?? raw.weekday_text ?? [];
+  if (typeof openNow !== "boolean") return undefined;
+  return { openNow, weekdayText };
+}
 
 function resolvePhotoUrls(row: Pick<VenueRow, "photo_url" | "photo_urls">): readonly string[] {
   if (Array.isArray(row.photo_urls) && row.photo_urls.length > 0) {
@@ -139,6 +173,7 @@ function resolvePhotoUrls(row: Pick<VenueRow, "photo_url" | "photo_urls">): read
  */
 export function toVenue(row: VenueRow): Venue {
   const photoUrls = resolvePhotoUrls(row);
+  const openingHours = toOpeningHours(row.opening_hours);
 
   return {
     id: row.id,
@@ -170,6 +205,16 @@ export function toVenue(row: VenueRow): Venue {
         timeOfDayFit: row.score_time_of_day_fit,
       }),
     },
+    ...(row.editorial_summary ? { editorialSummary: row.editorial_summary } : {}),
+    ...(typeof row.user_rating_count === "number"
+      ? { userRatingCount: row.user_rating_count }
+      : {}),
+    ...(openingHours ? { openingHours } : {}),
+    ...(typeof row.distance_meters === "number"
+      ? { distanceMeters: row.distance_meters }
+      : {}),
+    ...(row.website ? { website: row.website } : {}),
+    ...(row.why_picked ? { whyPicked: row.why_picked } : {}),
   };
 }
 
@@ -200,6 +245,9 @@ export type PlaceCandidate = {
   readonly photoReferences: readonly string[];
   readonly photoReference: string | null;
   readonly photoUrls: readonly string[];
+  readonly editorialSummary?: string;
+  readonly openingHours?: VenueOpeningHours;
+  readonly website?: string;
 };
 
 /**
@@ -224,4 +272,5 @@ export type CuratedVenueCandidate = PlaceCandidate & {
   readonly category: Category;
   readonly score: VenueScore;
   readonly tags: readonly string[];
+  readonly whyPicked?: string;
 };

--- a/web-service/supabase/migrations/013_enrich_venues.sql
+++ b/web-service/supabase/migrations/013_enrich_venues.sql
@@ -1,0 +1,17 @@
+-- 013_enrich_venues.sql
+-- DS-03: Enrich venues with editorial summary, review count, opening hours,
+-- distance from midpoint, website, and AI "why picked" reasoning.
+--
+-- All columns are nullable — venues predating this migration (or Google
+-- responses that omit these fields) remain valid.
+
+ALTER TABLE venues
+  ADD COLUMN IF NOT EXISTS editorial_summary text,
+  ADD COLUMN IF NOT EXISTS user_rating_count integer
+    CHECK (user_rating_count IS NULL OR user_rating_count >= 0),
+  ADD COLUMN IF NOT EXISTS opening_hours jsonb,
+  ADD COLUMN IF NOT EXISTS distance_meters double precision
+    CHECK (distance_meters IS NULL OR distance_meters >= 0),
+  ADD COLUMN IF NOT EXISTS website text,
+  ADD COLUMN IF NOT EXISTS why_picked text
+    CHECK (why_picked IS NULL OR char_length(why_picked) <= 140);


### PR DESCRIPTION
## Summary
- Extend `Venue` type with `editorialSummary`, `userRatingCount`, `openingHours`, `distanceMeters`, `website`, `whyPicked`
- Add Places API fields (`editorialSummary`, `regularOpeningHours`, `currentOpeningHours`, `websiteUri`) to the field mask and propagate through `PlaceCandidate`
- Persist new columns via migration `013_enrich_venues.sql` (all nullable, non-breaking)
- Compute haversine distance from midpoint at persist time
- New `venue-why-picked` service emits a deterministic <=140-char blurb citing rating, distance, and editorial signals; persisted per venue
- Swipe deck card now shows editorial summary (italic line-clamp-2 under address), rating with review count ("4.4 · 1.2k reviews"), distance pill, open-now indicator, and a raspberry-tinted "Why we picked this" card above Pass/Like — all conditional on data presence

Closes #107

## Test plan
- [x] `bun run test` (419 tests pass, incl. new `venue-why-picked` and `venue-enriched` suites)
- [x] `bun run lint` (clean, only pre-existing warnings)
- [x] `bun run build` succeeds
- [ ] Manual: run a new session end-to-end and verify enriched fields render on the swipe card when Google returns them

🤖 Generated with [Claude Code](https://claude.com/claude-code)