### PR TITLE
fix: round transition and fallback pick screen contrast (#110)

### DIFF
--- a/web-service/src/app/plan/[id]/results/result-screen.tsx
+++ b/web-service/src/app/plan/[id]/results/result-screen.tsx
@@ -438,7 +438,7 @@ export function ResultScreen({
                     setAuthError(null);
                     setAuthOpen(true);
                   }}
-                  className="h-11 rounded-[0.95rem] text-[1rem]"
+                  className="h-11 rounded-[0.95rem] text-[1rem] hover:bg-[#4a1224] hover:text-white"
                 >
                   Create account
                 </Button>

--- a/web-service/src/app/plan/[id]/results/result-screen.tsx
+++ b/web-service/src/app/plan/[id]/results/result-screen.tsx
@@ -438,7 +438,7 @@ export function ResultScreen({
                     setAuthError(null);
                     setAuthOpen(true);
                   }}
-                  className="h-11 rounded-[0.95rem] bg-[#4a1224] text-[1rem] text-white hover:bg-[#3a0e1c]"
+                  className="h-11 rounded-[0.95rem] text-[1rem]"
                 >
                   Create account
                 </Button>

--- a/web-service/src/app/plan/[id]/swipe/fallback-ending-screen.tsx
+++ b/web-service/src/app/plan/[id]/swipe/fallback-ending-screen.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image";
 import { useState } from "react";
-import { Button } from "../../../../components/button";
 import { CategoryIcon } from "../../../../components/category-icon";
 import type { BudgetLevel, Category } from "../../../../lib/types/preference";
 
@@ -68,27 +67,30 @@ export function FallbackEndingScreen({
     );
   }
 
+  const retryDisabled =
+    submittingAction !== null || selectedCategories.length === 0;
+
   return (
-    <section className="mx-auto max-w-3xl rounded-[2.25rem] border border-white/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.95),rgba(255,244,246,0.96))] px-6 py-8 shadow-[0_24px_80px_rgba(45,42,38,0.12)] backdrop-blur-xl sm:px-8 sm:py-10">
+    <section className="mx-auto max-w-3xl rounded-[2.25rem] border border-white/12 bg-white/[0.05] px-6 py-8 shadow-[0_30px_80px_rgba(0,0,0,0.45)] backdrop-blur-xl sm:px-8 sm:py-10">
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr] lg:items-start">
         <div>
-          <p className="text-caption font-semibold uppercase tracking-[0.24em] text-secondary">
+          <p className="text-caption font-semibold uppercase tracking-[0.24em] text-[#ff8da8]">
             Dateflow fallback pick
           </p>
-          <h1 className="mt-3 max-w-xl text-[clamp(2.5rem,6vw,4.5rem)] font-semibold leading-[0.94] tracking-[-0.05em] text-text">
+          <h1 className="mt-3 max-w-xl text-[clamp(2.5rem,6vw,4.5rem)] font-semibold leading-[0.94] tracking-[-0.05em] text-white">
             No mutual match this time
           </h1>
-          <p className="mt-4 max-w-2xl text-body text-text-secondary">
+          <p className="mt-4 max-w-2xl text-body text-white/75">
             You and {creatorName} did not land on the same venue, so Dateflow pulled forward the best next option instead of ending the night flat.
           </p>
-          <p className="mt-4 max-w-2xl text-body text-text-secondary">
+          <p className="mt-4 max-w-2xl text-body text-white/75">
             {explanation}
           </p>
         </div>
 
-        <div className="rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_18px_40px_rgba(45,42,38,0.08)]">
+        <div className="rounded-[1.75rem] border border-white/15 bg-white/[0.07] p-5 shadow-[0_18px_40px_rgba(0,0,0,0.35)] backdrop-blur-md">
           {venuePhotoUrl ? (
-            <div className="mb-4 overflow-hidden rounded-[1.35rem] border border-white/70">
+            <div className="mb-4 overflow-hidden rounded-[1.35rem] border border-white/15">
               <Image
                 src={venuePhotoUrl}
                 alt={venueName}
@@ -99,24 +101,24 @@ export function FallbackEndingScreen({
               />
             </div>
           ) : null}
-          <p className="text-caption font-semibold uppercase tracking-[0.2em] text-secondary">
+          <p className="text-caption font-semibold uppercase tracking-[0.2em] text-[#ff8da8]">
             Suggested venue
           </p>
-          <h2 className="mt-3 text-[1.8rem] font-semibold leading-tight tracking-[-0.03em] text-text">
+          <h2 className="mt-3 text-[1.8rem] font-semibold leading-tight tracking-[-0.03em] text-white">
             {venueName}
           </h2>
-          <p className="mt-2 inline-flex rounded-full border border-muted bg-bg px-3 py-1 text-caption font-medium text-text-secondary">
+          <p className="mt-3 inline-flex rounded-full border border-[rgba(208,61,106,0.4)] bg-[rgba(208,61,106,0.14)] px-3 py-1 text-caption font-medium text-[#ffb3c5]">
             {venueCategoryLabel}
           </p>
-          <p className="mt-4 text-body text-text-secondary">{venueAddress}</p>
+          <p className="mt-4 text-body text-white/70">{venueAddress}</p>
         </div>
       </div>
 
-      <div className="mt-8 rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_18px_40px_rgba(45,42,38,0.08)]">
-        <p className="text-caption font-semibold uppercase tracking-[0.2em] text-secondary">
+      <div className="mt-8 rounded-[1.75rem] border border-white/15 bg-white/[0.07] p-5 shadow-[0_18px_40px_rgba(0,0,0,0.35)] backdrop-blur-md">
+        <p className="text-caption font-semibold uppercase tracking-[0.2em] text-[#ff8da8]">
           Try a new mix
         </p>
-        <p className="mt-3 max-w-2xl text-body text-text-secondary">
+        <p className="mt-3 max-w-2xl text-body text-white/75">
           If {venueName} is not the move, tighten the vibe below and Dateflow will reshuffle the shortlist around a fresh direction.
         </p>
 
@@ -132,8 +134,8 @@ export function FallbackEndingScreen({
                 onClick={() => toggleCategory(value)}
                 className={`flex cursor-pointer items-center gap-3 rounded-[1.35rem] border px-4 py-3 text-left transition-colors duration-200 ${
                   isSelected
-                    ? "border-primary bg-primary text-white"
-                    : "border-muted bg-bg text-text-secondary hover:border-text-secondary"
+                    ? "border-[rgba(208,61,106,0.75)] bg-[rgba(208,61,106,0.25)] text-white"
+                    : "border-white/15 bg-white/[0.04] text-white/75 hover:border-white/35 hover:text-white"
                 }`}
               >
                 <CategoryIcon category={value} className="h-5 w-5" />
@@ -160,8 +162,8 @@ export function FallbackEndingScreen({
                 onClick={() => setSelectedBudget(value)}
                 className={`flex cursor-pointer flex-col items-center justify-center rounded-[1.25rem] border px-3 py-3 transition-colors duration-200 ${
                   isSelected
-                    ? "border-secondary bg-secondary-muted text-secondary"
-                    : "border-muted bg-bg text-text-secondary hover:border-text-secondary"
+                    ? "border-[rgba(208,61,106,0.75)] bg-[rgba(208,61,106,0.22)] text-white"
+                    : "border-white/15 bg-white/[0.04] text-white/70 hover:border-white/35 hover:text-white"
                 }`}
               >
                 <span className="text-body font-bold">{symbol}</span>
@@ -173,35 +175,38 @@ export function FallbackEndingScreen({
       </div>
 
       <div className="mt-8 grid gap-3 sm:grid-cols-2">
-        <Button
+        <button
+          type="button"
           onClick={onAccept}
           disabled={submittingAction !== null}
+          className="flex h-14 w-full items-center justify-center gap-2 rounded-2xl border border-[#10a37f] bg-[#10a37f] text-body font-semibold text-white shadow-[0_14px_30px_rgba(16,163,127,0.35)] transition-all duration-200 hover:bg-[#0e8e6f] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {submittingAction === "accept" ? "Locking it in..." : "Lock in this plan"}
-        </Button>
-        <Button
-          variant="secondary"
+        </button>
+        <button
+          type="button"
           onClick={() =>
             onRetry({
               categories: selectedCategories,
               budget: selectedBudget,
             })
           }
-          disabled={submittingAction !== null || selectedCategories.length === 0}
+          disabled={retryDisabled}
+          className="flex h-14 w-full items-center justify-center gap-2 rounded-2xl border border-[rgba(208,61,106,0.55)] bg-[rgba(208,61,106,0.14)] text-body font-semibold text-white transition-all duration-200 hover:bg-[rgba(208,61,106,0.22)] hover:border-[rgba(208,61,106,0.8)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80 disabled:cursor-not-allowed disabled:opacity-45"
         >
           {submittingAction === "retry" ? "Refreshing picks..." : "Try a new mix"}
-        </Button>
+        </button>
       </div>
 
       {errorMessage ? (
-        <p className="mt-4 text-body font-medium text-secondary">{errorMessage}</p>
+        <p className="mt-4 text-body font-medium text-[#ffb3c5]">{errorMessage}</p>
       ) : null}
 
       <div className="mt-4">
         <button
           type="button"
           onClick={onStartOver}
-          className="cursor-pointer text-body font-medium text-text-secondary transition-colors duration-200 hover:text-text"
+          className="cursor-pointer text-body font-medium text-white/60 transition-colors duration-200 hover:text-white"
         >
           Start over
         </button>

--- a/web-service/src/app/plan/[id]/swipe/swipe-flow.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-flow.tsx
@@ -74,6 +74,8 @@ export function SwipeFlow({
   const [showDeckInfo, setShowDeckInfo] = useState(false);
   const loadedRoundRef = useRef<number | null>(null);
   const loadingRoundRef = useRef<number | null>(null);
+  const loadedFallbackVenueIdRef = useRef<string | null>(null);
+  const loadingFallbackRef = useRef(false);
   const roundSwipesRef = useRef<Record<number, DemoRoundSwipe[]>>({});
   const demoRoundTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [toast, setToast] = useState<string | null>(
@@ -115,27 +117,46 @@ export function SwipeFlow({
   }, [sessionId]);
 
   const loadFallback = useCallback(async (matchedVenueId: string | null) => {
+    // Skip if we've already loaded this exact fallback venue, or a load is in
+    // flight. Prevents the status-sync polling loop from flashing the loading
+    // screen every few seconds while the user is on the fallback pick screen.
+    if (loadingFallbackRef.current) {
+      return;
+    }
+    if (
+      loadedFallbackVenueIdRef.current !== null &&
+      loadedFallbackVenueIdRef.current === (matchedVenueId ?? "")
+    ) {
+      return;
+    }
+
+    loadingFallbackRef.current = true;
     setStatus("loading");
     setStatusMessage("Preparing your fallback pick...");
 
-    const response = await fetch(`/api/sessions/${sessionId}/venues`);
+    try {
+      const response = await fetch(`/api/sessions/${sessionId}/venues`);
 
-    if (!response.ok) {
-      throw new Error("Failed to load the fallback suggestion.");
+      if (!response.ok) {
+        throw new Error("Failed to load the fallback suggestion.");
+      }
+
+      const body = (await response.json()) as { venues: Venue[] };
+      const resolvedVenue = resolveFallbackVenue(matchedVenueId, body.venues);
+
+      if (!resolvedVenue) {
+        throw new Error("We couldn't find the fallback venue for this session.");
+      }
+
+      setVenues(body.venues);
+      logVenuePhotoSnapshot("fallback", null, body.venues);
+      setFallbackVenue(resolvedVenue);
+      loadedFallbackVenueIdRef.current = matchedVenueId ?? "";
+      setStatus("fallback");
+      setStatusMessage("");
+    } finally {
+      loadingFallbackRef.current = false;
     }
-
-    const body = (await response.json()) as { venues: Venue[] };
-    const resolvedVenue = resolveFallbackVenue(matchedVenueId, body.venues);
-
-    if (!resolvedVenue) {
-      throw new Error("We couldn't find the fallback venue for this session.");
-    }
-
-    setVenues(body.venues);
-    logVenuePhotoSnapshot("fallback", null, body.venues);
-    setFallbackVenue(resolvedVenue);
-    setStatus("fallback");
-    setStatusMessage("");
   }, [logVenuePhotoSnapshot, sessionId]);
 
   const loadRound = useCallback(async (nextRound: number) => {
@@ -395,6 +416,7 @@ export function SwipeFlow({
     try {
       const result = await requestFallbackRetryDecision(sessionId, preferences);
       setFallbackVenue(null);
+      loadedFallbackVenueIdRef.current = null;
 
       if (result.status === "ready_to_swipe") {
         loadedRoundRef.current = null;

--- a/web-service/src/app/plan/[id]/swipe/swipe-flow.tsx
+++ b/web-service/src/app/plan/[id]/swipe/swipe-flow.tsx
@@ -127,6 +127,11 @@ export function SwipeFlow({
       loadedFallbackVenueIdRef.current !== null &&
       loadedFallbackVenueIdRef.current === (matchedVenueId ?? "")
     ) {
+      // Callers (e.g. bootstrap) may have flipped status to "loading" before
+      // dispatching here. Restore the fallback view so the UI doesn't stall
+      // on the loading screen.
+      setStatus("fallback");
+      setStatusMessage("");
       return;
     }
 

--- a/web-service/src/components/loading-ornament.tsx
+++ b/web-service/src/components/loading-ornament.tsx
@@ -162,15 +162,15 @@ function PartnerPreferencesLoader() {
 
 function PartnerRoundLoader() {
   return (
-    <div className="relative flex h-40 w-40 items-center justify-center" aria-hidden="true">
+    <div className="relative flex h-56 w-56 items-center justify-center" aria-hidden="true">
       <div
-        className="absolute inset-10 rounded-full opacity-80 blur-2xl"
+        className="absolute inset-12 rounded-full opacity-80 blur-2xl"
         style={{
           background:
             "radial-gradient(circle, rgba(255,61,127,0.32) 0%, rgba(232,160,138,0.1) 68%, transparent 100%)",
         }}
       />
-      <div className="absolute inset-[2.55rem] flex items-center justify-center rounded-full bg-white/90 shadow-[0_18px_38px_rgba(0,0,0,0.42)]">
+      <div className="absolute inset-[4.25rem] flex items-center justify-center rounded-full bg-white/90 shadow-[0_18px_38px_rgba(0,0,0,0.42)]">
         <div
           className="flex h-14 w-14 items-center justify-center rounded-full text-[#8a2346]"
           style={{ background: RASPBERRY_SOFT }}
@@ -182,18 +182,18 @@ function PartnerRoundLoader() {
         className="absolute inset-0 motion-safe:animate-spin motion-reduce:animate-none"
         style={{ animationDuration: "9s" }}
       >
-        <div className="absolute left-1/2 top-1 h-7 w-7 -translate-x-1/2 rounded-full bg-white/90 shadow-[0_14px_28px_rgba(0,0,0,0.4)]">
+        <div className="absolute left-1/2 top-0 h-8 w-8 -translate-x-1/2 rounded-full bg-white/90 shadow-[0_14px_28px_rgba(0,0,0,0.4)]">
           <div className="flex h-full items-center justify-center text-[#8a2346]">
-            <HeartIcon className="h-3.5 w-3.5" />
+            <HeartIcon className="h-4 w-4" />
           </div>
         </div>
       </div>
       <div
-        className="absolute inset-[0.85rem] motion-safe:animate-spin motion-reduce:animate-none"
+        className="absolute inset-0 motion-safe:animate-spin motion-reduce:animate-none"
         style={{ animationDirection: "reverse", animationDuration: "6.3s" }}
       >
-        <div className="absolute right-0 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 text-[#b22233] shadow-[0_12px_24px_rgba(0,0,0,0.4)]">
-          <PassIcon className="h-3.5 w-3.5" />
+        <div className="absolute right-0 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 text-[#b22233] shadow-[0_12px_24px_rgba(0,0,0,0.4)]">
+          <PassIcon className="h-4 w-4" />
         </div>
       </div>
     </div>

--- a/web-service/src/components/loading-ornament.tsx
+++ b/web-service/src/components/loading-ornament.tsx
@@ -135,8 +135,8 @@ function PartnerPreferencesLoader() {
       <div className="absolute bottom-8 left-11 flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-[#8a2346] shadow-[0_16px_30px_rgba(0,0,0,0.4)] motion-safe:animate-[floatHeart_2.4s_ease-in-out_infinite] motion-reduce:animate-none">
         <HeartIcon className="h-4 w-4" />
       </div>
-      <div className="absolute bottom-12 right-10 flex h-7 w-7 items-center justify-center rounded-full bg-white/85 text-[#4a302a] shadow-[0_14px_24px_rgba(0,0,0,0.35)] motion-safe:animate-[floatDot_2s_ease-in-out_infinite] motion-reduce:animate-none">
-        <div className="h-2.5 w-2.5 rounded-full bg-[#8a5a4a]" />
+      <div className="absolute bottom-12 right-10 flex h-8 w-8 items-center justify-center rounded-full bg-white/90 text-[#b22233] shadow-[0_14px_24px_rgba(0,0,0,0.35)] motion-safe:animate-[floatDot_2s_ease-in-out_infinite] motion-reduce:animate-none">
+        <PassIcon className="h-4 w-4" />
       </div>
       <div className="absolute inset-[2.6rem] flex items-center justify-center rounded-full bg-white/90 shadow-[0_18px_34px_rgba(0,0,0,0.4)]">
         <div
@@ -192,9 +192,9 @@ function PartnerRoundLoader() {
         className="absolute inset-[0.85rem] motion-safe:animate-spin motion-reduce:animate-none"
         style={{ animationDirection: "reverse", animationDuration: "6.3s" }}
       >
-        <div
-          className="absolute right-0 top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-[#e8a08a] shadow-[0_0_0_8px_rgba(232,160,138,0.18)]"
-        />
+        <div className="absolute right-0 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 text-[#b22233] shadow-[0_12px_24px_rgba(0,0,0,0.4)]">
+          <PassIcon className="h-3.5 w-3.5" />
+        </div>
       </div>
     </div>
   );
@@ -298,8 +298,35 @@ function ShortlistCard({
 
 function HeartIcon({ className }: { readonly className: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-      <path d="M12 21s-6.72-4.32-9.33-8.35C.96 10.01 1.53 6.5 4.43 4.84c2.35-1.35 4.85-.48 6.1 1.33 1.25-1.81 3.75-2.68 6.1-1.33 2.9 1.66 3.47 5.17 1.76 7.81C18.72 16.68 12 21 12 21Z" />
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 20.5c-.5 0-.98-.19-1.35-.53-2.5-2.3-4.6-4.2-6.07-6.08C3.14 12.04 2.5 10.4 2.5 8.75c0-2.9 2.24-5.25 5-5.25 1.77 0 3.38.92 4.25 2.33.87-1.41 2.48-2.33 4.25-2.33 2.76 0 5 2.35 5 5.25 0 1.65-.64 3.29-2.08 5.14-1.47 1.88-3.57 3.78-6.07 6.08-.37.34-.85.53-1.35.53Z" />
+    </svg>
+  );
+}
+
+function PassIcon({ className }: { readonly className: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9.25" />
+      <path d="M8.5 8.5 15.5 15.5" />
+      <path d="M15.5 8.5 8.5 15.5" />
     </svg>
   );
 }


### PR DESCRIPTION
Closes #110

## Summary
- Between-round waiting animation now shows both a heart and a circled-X pass glyph, using the same icon treatment as the swipe deck.
- Fallback pick screen moved to the dark wine-glass canvas so text contrast is readable; category/budget pills use raspberry-tinted selected states.
- CTA hierarchy fixed: **Lock in this plan** is a solid green commit button; **Try a new mix** is a raspberry-outlined glass secondary. Previously both read as white/undifferentiated pills.

## Test plan
- [x] \`bun run test\` — 426/426 pass
- [x] \`bun run lint\` — clean (2 pre-existing unused-var warnings)
- [x] \`bun run build\` — succeeds
- [x] Visually verify fallback screen contrast on the wine canvas
- [x] Visually verify the between-round loader shows both heart + pass glyphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)