### PR TITLE
feat: filter poor first-date venues

### DIFF
--- a/web-service/src/lib/services/__tests__/ai-curation-service.test.ts
+++ b/web-service/src/lib/services/__tests__/ai-curation-service.test.ts
@@ -122,6 +122,47 @@ describe("scoreAndCurate", () => {
     );
   });
 
+  it("prefers park-style venues for budget-first date preferences", async () => {
+    const budgetPreferences: readonly [Preference, Preference] = [
+      {
+        ...preferences[0],
+        budget: "BUDGET",
+        categories: ["ACTIVITY", "RESTAURANT"],
+      },
+      {
+        ...preferences[1],
+        budget: "BUDGET",
+        categories: ["ACTIVITY", "RESTAURANT"],
+      },
+    ];
+
+    const ranked = buildDeterministicRanking(
+      [
+        makeCandidate("cheap-restaurant", {
+          name: "Budget Bites",
+          types: ["restaurant"],
+          primaryType: "restaurant",
+          priceLevel: 1,
+          rating: 4.8,
+          reviewCount: 480,
+        }),
+        makeCandidate("park-date", {
+          name: "Lakeside Park",
+          types: ["park", "tourist_attraction"],
+          primaryType: "park",
+          priceLevel: 0,
+          rating: 4.0,
+          reviewCount: 85,
+        }),
+      ],
+      budgetPreferences,
+      1,
+      midpoint,
+    );
+
+    expect(ranked[0].placeId).toBe("park-date");
+  });
+
   it("extracts deterministic finalists and only lets AI touch allowed fields", async () => {
     const deterministic = buildDeterministicRanking(
       [

--- a/web-service/src/lib/services/__tests__/places-api-cached.test.ts
+++ b/web-service/src/lib/services/__tests__/places-api-cached.test.ts
@@ -58,7 +58,7 @@ describe("searchNearbyWithCache", () => {
     vi.clearAllMocks();
     // Get the mock cache instance that VenueCache constructor returns
     mockCache = new VenueCache() as unknown as typeof mockCache;
-    mockCache.buildKey.mockReturnValue("venue:cache:30.27:-97.74:BAR:RESTAURANT:3");
+    mockCache.buildKey.mockReturnValue("venue:cache:v2:30.27:-97.74:BAR:RESTAURANT:3");
   });
 
   it("returns cached results on cache hit (no API call)", async () => {
@@ -67,7 +67,7 @@ describe("searchNearbyWithCache", () => {
     const results = await searchNearbyWithCache(location, radius, categories, maxPrice);
 
     expect(results).toEqual(fakeCandidates);
-    expect(mockCache.get).toHaveBeenCalledWith("venue:cache:30.27:-97.74:BAR:RESTAURANT:3:radius=2000");
+    expect(mockCache.get).toHaveBeenCalledWith("venue:cache:v2:30.27:-97.74:BAR:RESTAURANT:3:radius=2000");
     expect(searchNearby).not.toHaveBeenCalled();
   });
 
@@ -83,10 +83,41 @@ describe("searchNearbyWithCache", () => {
     const expectedGoogleTypes = ["restaurant", "cafe", "bakery", "bar", "night_club"];
     expect(searchNearby).toHaveBeenCalledWith(location, radius, expectedGoogleTypes, maxPrice);
     expect(mockCache.set).toHaveBeenCalledWith(
-      "venue:cache:30.27:-97.74:BAR:RESTAURANT:3:radius=2000",
+      "venue:cache:v2:30.27:-97.74:BAR:RESTAURANT:3:radius=2000",
       fakeCandidates,
       CACHE_TTL_SECONDS
     );
+  });
+
+  it("filters stale cached candidates on cache hit before returning them", async () => {
+    mockCache.get.mockResolvedValueOnce([
+      {
+        ...fakeCandidates[0],
+        placeId: "chain-1",
+        name: "McDonald's",
+        types: ["restaurant", "food"],
+        primaryType: "restaurant",
+      },
+      {
+        ...fakeCandidates[0],
+        placeId: "gym-1",
+        name: "City Gym",
+        types: ["gym", "point_of_interest"],
+        primaryType: "gym",
+      },
+      {
+        ...fakeCandidates[0],
+        placeId: "good-1",
+        name: "Neighborhood Cafe",
+        types: ["cafe", "restaurant"],
+        primaryType: "cafe",
+      },
+    ] satisfies readonly PlaceCandidate[]);
+
+    const results = await searchNearbyWithCache(location, radius, categories, maxPrice);
+
+    expect(results.map((candidate) => candidate.placeId)).toEqual(["good-1"]);
+    expect(searchNearby).not.toHaveBeenCalled();
   });
 
   it("passes correct TTL to cache (6 hours)", () => {

--- a/web-service/src/lib/services/__tests__/places-api-client.test.ts
+++ b/web-service/src/lib/services/__tests__/places-api-client.test.ts
@@ -358,5 +358,88 @@ describe("places-api-client", () => {
       expect(body).not.toHaveProperty("includedPrimaryTypes");
       expect(results.map((result) => result.placeId)).toEqual(["budget-ok"]);
     });
+
+    it("excludes deny-listed venue types while keeping valid activity venues", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          places: [
+            {
+              id: "gym-1",
+              displayName: { text: "Downtown Climbing Gym" },
+              formattedAddress: "1 Fitness Way",
+              location: { latitude: 30.0, longitude: -97.0 },
+              types: ["gym", "point_of_interest", "establishment"],
+              primaryType: "gym",
+              rating: 4.6,
+              userRatingCount: 300,
+              photos: [],
+            },
+            {
+              id: "liquor-1",
+              displayName: { text: "Bottle Shop" },
+              formattedAddress: "2 Spirits Ave",
+              location: { latitude: 30.0, longitude: -97.0 },
+              types: ["liquor_store", "store", "point_of_interest"],
+              primaryType: "liquor_store",
+              rating: 4.2,
+              userRatingCount: 120,
+              photos: [],
+            },
+            {
+              id: "rink-1",
+              displayName: { text: "Moonlight Roller Rink" },
+              formattedAddress: "3 Date Night Dr",
+              location: { latitude: 30.0, longitude: -97.0 },
+              types: ["roller_skating_rink", "point_of_interest", "restaurant"],
+              primaryType: "roller_skating_rink",
+              rating: 4.7,
+              userRatingCount: 410,
+              photos: [],
+            },
+          ],
+        }),
+      });
+
+      const results = await searchNearby(location, 2000, ["restaurant", "activity"], 4);
+
+      expect(results.map((result) => result.placeId)).toEqual(["rink-1"]);
+    });
+
+    it("excludes fast-food chains by name while keeping cafes", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          places: [
+            {
+              id: "fast-food-1",
+              displayName: { text: "McDonald's" },
+              formattedAddress: "4 Chain Ln",
+              location: { latitude: 30.0, longitude: -97.0 },
+              types: ["restaurant", "food", "point_of_interest"],
+              primaryType: "restaurant",
+              rating: 3.9,
+              userRatingCount: 1200,
+              photos: [],
+            },
+            {
+              id: "cafe-1",
+              displayName: { text: "Morning Bloom Cafe" },
+              formattedAddress: "5 Slow Date St",
+              location: { latitude: 30.0, longitude: -97.0 },
+              types: ["cafe", "restaurant", "food"],
+              primaryType: "cafe",
+              rating: 4.6,
+              userRatingCount: 210,
+              photos: [],
+            },
+          ],
+        }),
+      });
+
+      const results = await searchNearby(location, 2000, ["restaurant"], 2);
+
+      expect(results.map((result) => result.placeId)).toEqual(["cafe-1"]);
+    });
   });
 });

--- a/web-service/src/lib/services/ai-curation-service.ts
+++ b/web-service/src/lib/services/ai-curation-service.ts
@@ -98,7 +98,7 @@ function roundBonus(category: Category, round: number): number {
   return 0;
 }
 
-const BUDGET_ROMANTIC_PRIMARY_TYPES = new Set<string>([
+const BUDGET_ROMANTIC_TYPES = new Set<string>([
   "park",
   "botanical_garden",
   "tourist_attraction",
@@ -121,14 +121,14 @@ function budgetRomanticBonus(
 
   const hasBudgetPrimaryType =
     candidate.primaryType !== null &&
-    BUDGET_ROMANTIC_PRIMARY_TYPES.has(candidate.primaryType);
+    BUDGET_ROMANTIC_TYPES.has(candidate.primaryType);
   const hasBudgetFriendlyType = candidate.types.some((type) =>
-    BUDGET_ROMANTIC_PRIMARY_TYPES.has(type),
+    BUDGET_ROMANTIC_TYPES.has(type),
   );
 
   const baseMultiplier = budgetPreferenceCount === 2 ? 1 : 0.65;
 
-  if ((hasBudgetPrimaryType || hasBudgetFriendlyType) && candidate.priceLevel === 0) {
+  if (hasBudgetPrimaryType || hasBudgetFriendlyType) {
     return 0.28 * baseMultiplier;
   }
 

--- a/web-service/src/lib/services/ai-curation-service.ts
+++ b/web-service/src/lib/services/ai-curation-service.ts
@@ -98,6 +98,47 @@ function roundBonus(category: Category, round: number): number {
   return 0;
 }
 
+const BUDGET_ROMANTIC_PRIMARY_TYPES = new Set<string>([
+  "park",
+  "botanical_garden",
+  "tourist_attraction",
+  "art_gallery",
+  "museum",
+]);
+
+function budgetRomanticBonus(
+  candidate: PlaceCandidate,
+  category: Category,
+  preferences: readonly [Preference, Preference],
+): number {
+  const budgetPreferenceCount = preferences.filter(
+    (preference) => preference.budget === "BUDGET",
+  ).length;
+
+  if (budgetPreferenceCount === 0) {
+    return 0;
+  }
+
+  const hasBudgetPrimaryType =
+    candidate.primaryType !== null &&
+    BUDGET_ROMANTIC_PRIMARY_TYPES.has(candidate.primaryType);
+  const hasBudgetFriendlyType = candidate.types.some((type) =>
+    BUDGET_ROMANTIC_PRIMARY_TYPES.has(type),
+  );
+
+  const baseMultiplier = budgetPreferenceCount === 2 ? 1 : 0.65;
+
+  if ((hasBudgetPrimaryType || hasBudgetFriendlyType) && candidate.priceLevel === 0) {
+    return 0.28 * baseMultiplier;
+  }
+
+  if (category === "RESTAURANT" && candidate.primaryType === "cafe") {
+    return 0.12 * baseMultiplier;
+  }
+
+  return 0;
+}
+
 function categoryOverlapScore(
   category: Category,
   preferences: readonly [Preference, Preference]
@@ -197,7 +238,12 @@ export function buildDeterministicRanking(
         composite: baseComposite,
       };
 
-      const rankingComposite = Math.min(1, baseComposite + roundBonus(category, round));
+      const rankingComposite = Math.min(
+        1,
+        baseComposite +
+          roundBonus(category, round) +
+          budgetRomanticBonus(candidate, category, preferences),
+      );
 
       return {
         rankingComposite,

--- a/web-service/src/lib/services/places-api-cached.ts
+++ b/web-service/src/lib/services/places-api-cached.ts
@@ -1,7 +1,11 @@
 import type { Location, Category } from "../types/preference";
 import type { PlaceCandidate } from "../types/venue";
 import { VenueCache } from "./venue-cache";
-import { searchNearby, categoriesToGoogleTypes } from "./places-api-client";
+import {
+  searchNearby,
+  categoriesToGoogleTypes,
+  filterDeniedFirstDateVenues,
+} from "./places-api-client";
 
 /**
  * Cache TTL: 6 hours in seconds.
@@ -48,15 +52,16 @@ export async function searchNearbyWithCache(
     try {
       const cached = await cache.get(cacheKey);
       if (cached) {
+        const filteredCached = filterDeniedFirstDateVenues(cached);
         console.info("[searchNearbyWithCache] cache hit", {
           cacheKey,
-          candidateCount: cached.length,
+          candidateCount: filteredCached.length,
           locationLabel: location.label,
           radius,
           categories,
           maxPrice,
         });
-        return cached;
+        return filteredCached;
       }
 
       console.info("[searchNearbyWithCache] cache miss", {

--- a/web-service/src/lib/services/places-api-client.ts
+++ b/web-service/src/lib/services/places-api-client.ts
@@ -176,10 +176,14 @@ function isFastFoodChainName(name: string): boolean {
   return FAST_FOOD_CHAIN_PATTERNS.some((pattern) => pattern.test(name));
 }
 
-function isDeniedFirstDateVenue(
-  place: Pick<GooglePlace, "displayName" | "types" | "primaryType">,
-): boolean {
-  if (isFastFoodChainName(place.displayName.text)) {
+type FirstDateVenueLike = {
+  readonly name: string;
+  readonly types: readonly string[];
+  readonly primaryType?: string | null;
+};
+
+export function isDeniedFirstDateVenue(place: FirstDateVenueLike): boolean {
+  if (isFastFoodChainName(place.name)) {
     return true;
   }
 
@@ -188,6 +192,12 @@ function isDeniedFirstDateVenue(
   }
 
   return place.types.some((type) => DENY_LISTED_PLACE_TYPES.has(type));
+}
+
+export function filterDeniedFirstDateVenues<T extends FirstDateVenueLike>(
+  places: readonly T[],
+): readonly T[] {
+  return places.filter((place) => !isDeniedFirstDateVenue(place));
 }
 
 /**
@@ -342,9 +352,12 @@ export async function searchNearby(
   }
 
   const data = await response.json();
-  const places: readonly GooglePlace[] = (data.places ?? []).filter(
-    (place: GooglePlace) => !isDeniedFirstDateVenue(place),
-  );
+  const places: readonly GooglePlace[] = filterDeniedFirstDateVenues(
+    ((data.places ?? []) as readonly GooglePlace[]).map((place) => ({
+      ...place,
+      name: place.displayName.text,
+    })),
+  ).map(({ name: _name, ...place }) => place);
 
   const candidates: readonly PlaceCandidate[] = places.map((place) => {
     const photoReferences = (place.photos ?? []).map((photo) => photo.name);

--- a/web-service/src/lib/services/places-api-client.ts
+++ b/web-service/src/lib/services/places-api-client.ts
@@ -151,6 +151,45 @@ const CATEGORY_PRIORITY: readonly Category[] = [
   "ACTIVITY",
 ];
 
+const DENY_LISTED_PLACE_TYPES = new Set<string>([
+  "gym",
+  "liquor_store",
+  "convenience_store",
+  "gas_station",
+  "funeral_home",
+  "car_wash",
+]);
+
+const FAST_FOOD_CHAIN_PATTERNS: readonly RegExp[] = [
+  /\bmcdonald'?s\b/i,
+  /\btaco bell\b/i,
+  /\bkfc\b/i,
+  /\bburger king\b/i,
+  /\bwendy'?s\b/i,
+  /\bchick-?fil-?a\b/i,
+  /\bsubway\b/i,
+  /\bdomino'?s\b/i,
+  /\bpizza hut\b/i,
+];
+
+function isFastFoodChainName(name: string): boolean {
+  return FAST_FOOD_CHAIN_PATTERNS.some((pattern) => pattern.test(name));
+}
+
+function isDeniedFirstDateVenue(
+  place: Pick<GooglePlace, "displayName" | "types" | "primaryType">,
+): boolean {
+  if (isFastFoodChainName(place.displayName.text)) {
+    return true;
+  }
+
+  if (place.primaryType && DENY_LISTED_PLACE_TYPES.has(place.primaryType)) {
+    return true;
+  }
+
+  return place.types.some((type) => DENY_LISTED_PLACE_TYPES.has(type));
+}
+
 /**
  * Given a Google Places `primaryType` and full `types` array, returns the
  * best-matching Category. Prefers `primaryType` when it maps to a known
@@ -303,7 +342,9 @@ export async function searchNearby(
   }
 
   const data = await response.json();
-  const places: readonly GooglePlace[] = data.places ?? [];
+  const places: readonly GooglePlace[] = (data.places ?? []).filter(
+    (place: GooglePlace) => !isDeniedFirstDateVenue(place),
+  );
 
   const candidates: readonly PlaceCandidate[] = places.map((place) => {
     const photoReferences = (place.photos ?? []).map((photo) => photo.name);

--- a/web-service/src/lib/services/venue-cache.ts
+++ b/web-service/src/lib/services/venue-cache.ts
@@ -36,7 +36,7 @@ export class VenueCache {
    * Categories are sorted alphabetically so different orderings produce the same key.
    * Price level is included so different budget tiers cache separately.
    *
-   * Example: `venue:cache:30.27:-97.74:BAR:RESTAURANT:2`
+   * Example: `venue:cache:v2:30.27:-97.74:BAR:RESTAURANT:2`
    */
   buildKey(
     location: Location,

--- a/web-service/src/lib/services/venue-cache.ts
+++ b/web-service/src/lib/services/venue-cache.ts
@@ -15,6 +15,7 @@ import type { Location } from "../types/preference";
  */
 export class VenueCache {
   private redis = getRedisClient();
+  private static readonly KEY_VERSION = "v2";
 
   private getValuePreview(value: unknown): string {
     if (typeof value === "string") {
@@ -49,7 +50,7 @@ export class VenueCache {
     // Sort categories so order doesn't matter
     const sortedCategories = [...categories].sort().join(":");
 
-    return `venue:cache:${lat}:${lng}:${sortedCategories}:${priceLevel}`;
+    return `venue:cache:${VenueCache.KEY_VERSION}:${lat}:${lng}:${sortedCategories}:${priceLevel}`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- add first-date deny-list filtering for gyms, liquor stores, and fast-food chains during Places ingestion
- bias budget deterministic ranking toward free romantic alternatives like parks, museums, galleries, and cafes
- version the venue cache and sanitize cached candidates on read so stale bad spots do not keep surfacing

## Test plan
- [x] `bun run test -- src/lib/services/__tests__/places-api-client.test.ts`
- [x] `bun run test -- src/lib/services/__tests__/places-api-cached.test.ts`
- [x] `bun run test -- src/lib/services/__tests__/ai-curation-service.test.ts`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run lint` (2 pre-existing warnings, 0 errors)