### PR TITLE
feat: DS-07A schedule preference fields and preference flow screen

### DIFF
--- a/web-service/src/app/api/sessions/[id]/preferences/__tests__/route.test.ts
+++ b/web-service/src/app/api/sessions/[id]/preferences/__tests__/route.test.ts
@@ -452,6 +452,63 @@ describe("POST /api/sessions/[id]/preferences", () => {
     expect(body.error).toContain("already submitted");
   });
 
+  // --- Schedule field validation ---
+
+  it("accepts valid schedule fields and passes them to submitPreference", async () => {
+    const response = await POST(
+      makePostRequest({
+        ...validBody,
+        scheduleWindow: "this_week",
+        availableDays: ["sat", "sun"],
+        timeOfDay: "evening",
+      }),
+      makeParams(),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockSubmitPreference).toHaveBeenCalledWith(SESSION_ID, {
+      role: "b",
+      location: { lat: 30.2672, lng: -97.7431, label: "Downtown Austin" },
+      budget: "MODERATE",
+      categories: ["RESTAURANT", "BAR"],
+      scheduleWindow: "this_week",
+      availableDays: ["sat", "sun"],
+      timeOfDay: "evening",
+    });
+  });
+
+  it("returns 400 when scheduleWindow is an invalid value", async () => {
+    const response = await POST(
+      makePostRequest({ ...validBody, scheduleWindow: "yesterday" }),
+      makeParams(),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when availableDays contains an invalid day", async () => {
+    const response = await POST(
+      makePostRequest({ ...validBody, availableDays: ["sat", "monday"] }),
+      makeParams(),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when availableDays is an empty array", async () => {
+    const response = await POST(
+      makePostRequest({ ...validBody, availableDays: [] }),
+      makeParams(),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when timeOfDay is an invalid value", async () => {
+    const response = await POST(
+      makePostRequest({ ...validBody, timeOfDay: "midnight" }),
+      makeParams(),
+    );
+    expect(response.status).toBe(400);
+  });
+
   // --- Unexpected errors ---
 
   it("returns 500 on unexpected error without leaking details", async () => {

--- a/web-service/src/app/api/sessions/[id]/preferences/route.ts
+++ b/web-service/src/app/api/sessions/[id]/preferences/route.ts
@@ -14,7 +14,14 @@ import { isExpired } from "../../../../../lib/services/session-helpers";
 import { generateDemoVenues } from "../../../../../lib/services/demo-venue-service";
 import { generateVenues } from "../../../../../lib/services/venue-generation-service";
 import { buildSessionRoleCookieValue } from "../../../../../lib/session-role-access";
-import type { BudgetLevel, Category, Role } from "../../../../../lib/types/preference";
+import type {
+  BudgetLevel,
+  Category,
+  DayOfWeek,
+  Role,
+  ScheduleWindow,
+  TimeOfDay,
+} from "../../../../../lib/types/preference";
 
 type RouteParams = {
   params: Promise<{ id: string }>;
@@ -38,6 +45,27 @@ const VALID_CATEGORIES: readonly Category[] = [
   "EVENT",
 ];
 const MAX_CATEGORIES = 4;
+const VALID_SCHEDULE_WINDOWS: readonly ScheduleWindow[] = [
+  "this_week",
+  "next_week",
+  "two_weeks",
+  "flexible",
+];
+const VALID_DAYS_OF_WEEK: readonly DayOfWeek[] = [
+  "mon",
+  "tue",
+  "wed",
+  "thu",
+  "fri",
+  "sat",
+  "sun",
+];
+const VALID_TIMES_OF_DAY: readonly TimeOfDay[] = [
+  "afternoon",
+  "evening",
+  "night",
+  "any",
+];
 const SESSION_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -53,6 +81,9 @@ type ValidationResult =
       location: { lat: number; lng: number; label: string };
       budget: BudgetLevel;
       categories: Category[];
+      scheduleWindow?: ScheduleWindow;
+      availableDays?: DayOfWeek[];
+      timeOfDay?: TimeOfDay;
       demo: boolean;
     }
   | { valid: false; error: string };
@@ -62,7 +93,17 @@ function validateBody(body: unknown): ValidationResult {
     return { valid: false, error: "Request body must be a JSON object" };
   }
 
-  const { role, displayName, location, budget, categories, demo } = body as Record<string, unknown>;
+  const {
+    role,
+    displayName,
+    location,
+    budget,
+    categories,
+    scheduleWindow,
+    availableDays,
+    timeOfDay,
+    demo,
+  } = body as Record<string, unknown>;
 
   // Role
   if (!role || !VALID_ROLES.includes(role as Role)) {
@@ -125,6 +166,25 @@ function validateBody(body: unknown): ValidationResult {
     return { valid: false, error: `Invalid category: ${invalidCategory}` };
   }
 
+  // Schedule fields (all optional)
+  if (scheduleWindow !== undefined && !VALID_SCHEDULE_WINDOWS.includes(scheduleWindow as ScheduleWindow)) {
+    return { valid: false, error: "scheduleWindow must be this_week, next_week, two_weeks, or flexible" };
+  }
+
+  if (availableDays !== undefined) {
+    if (!Array.isArray(availableDays) || availableDays.length === 0) {
+      return { valid: false, error: "availableDays must be a non-empty array" };
+    }
+    const invalidDay = availableDays.find((d: unknown) => !VALID_DAYS_OF_WEEK.includes(d as DayOfWeek));
+    if (invalidDay !== undefined) {
+      return { valid: false, error: `Invalid day: ${invalidDay}` };
+    }
+  }
+
+  if (timeOfDay !== undefined && !VALID_TIMES_OF_DAY.includes(timeOfDay as TimeOfDay)) {
+    return { valid: false, error: "timeOfDay must be afternoon, evening, night, or any" };
+  }
+
   return {
     valid: true,
     role: role as Role,
@@ -132,6 +192,9 @@ function validateBody(body: unknown): ValidationResult {
     location: { lat: lat as number, lng: lng as number, label: (label as string).trim() },
     budget: budget as BudgetLevel,
     categories: categories as Category[],
+    ...(scheduleWindow !== undefined ? { scheduleWindow: scheduleWindow as ScheduleWindow } : {}),
+    ...(availableDays !== undefined ? { availableDays: availableDays as DayOfWeek[] } : {}),
+    ...(timeOfDay !== undefined ? { timeOfDay: timeOfDay as TimeOfDay } : {}),
     demo: demo === true,
   };
 }
@@ -184,7 +247,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     return NextResponse.json({ error: validation.error }, { status: 400 });
   }
 
-  const { role, displayName, location, budget, categories, demo } = validation;
+  const { role, displayName, location, budget, categories, scheduleWindow, availableDays, timeOfDay, demo } = validation;
 
   try {
     // 3. Check session exists
@@ -231,6 +294,9 @@ export async function POST(request: Request, { params }: RouteParams) {
       location,
       budget,
       categories,
+      ...(scheduleWindow !== undefined ? { scheduleWindow } : {}),
+      ...(availableDays !== undefined ? { availableDays } : {}),
+      ...(timeOfDay !== undefined ? { timeOfDay } : {}),
     });
 
     if (role === "b" && displayName) {

--- a/web-service/src/app/plan/[id]/plan-flow.tsx
+++ b/web-service/src/app/plan/[id]/plan-flow.tsx
@@ -4,8 +4,16 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { HookScreen } from "../../../components/hook-screen";
 import { LoadingScreen } from "../../../components/loading-screen";
+import { ScheduleScreen } from "../../../components/schedule-screen";
 import { createSessionStatusSync } from "../../../lib/session-status-sync";
-import type { Location, BudgetLevel, Category } from "../../../lib/types/preference";
+import type {
+  Location,
+  BudgetLevel,
+  Category,
+  DayOfWeek,
+  ScheduleWindow,
+  TimeOfDay,
+} from "../../../lib/types/preference";
 import { getPlanFlowSyncAction } from "./plan-flow-state";
 
 type PlanFlowProps = {
@@ -22,7 +30,14 @@ type PlanFlowProps = {
  * single landing, then PlanFlow POSTs the bundled preferences and shows
  * the loading screen while the session transitions.
  */
-type FlowStep = "hook" | "loading";
+type FlowStep = "hook" | "schedule" | "loading";
+
+type HookData = {
+  displayName: string;
+  location: Location;
+  categories: Category[];
+  budget: BudgetLevel;
+};
 
 export function PlanFlow({
   sessionId,
@@ -32,15 +47,14 @@ export function PlanFlow({
 }: PlanFlowProps) {
   const router = useRouter();
   const [step, setStep] = useState<FlowStep>(initialStep);
-  const [location, setLocation] = useState<Location | null>(null);
-  const [inviteeDisplayName, setInviteeDisplayName] = useState("");
+  const [hookData, setHookData] = useState<HookData | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   async function submitPreferences(
-    loc: Location,
-    vibeCategories: Category[],
-    vibeBudget: BudgetLevel,
-    displayNameOverride?: string,
+    data: HookData,
+    scheduleWindow?: ScheduleWindow,
+    availableDays?: DayOfWeek[],
+    timeOfDay?: TimeOfDay,
   ) {
     try {
       const response = await fetch(
@@ -50,10 +64,13 @@ export function PlanFlow({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             role: "b",
-            displayName: displayNameOverride ?? inviteeDisplayName,
-            location: { lat: loc.lat, lng: loc.lng, label: loc.label },
-            budget: vibeBudget,
-            categories: vibeCategories,
+            displayName: data.displayName,
+            location: { lat: data.location.lat, lng: data.location.lng, label: data.location.label },
+            budget: data.budget,
+            categories: data.categories,
+            ...(scheduleWindow ? { scheduleWindow } : {}),
+            ...(availableDays ? { availableDays } : {}),
+            ...(timeOfDay ? { timeOfDay } : {}),
             demo: demoMode,
           }),
         }
@@ -95,13 +112,30 @@ export function PlanFlow({
     return (
       <HookScreen
         creatorName={creatorName}
-        initialDisplayName={inviteeDisplayName}
-        initialLocation={location}
+        initialDisplayName={hookData?.displayName ?? ""}
+        initialLocation={hookData?.location ?? null}
         onContinue={(data) => {
-          setInviteeDisplayName(data.displayName);
-          setLocation(data.location);
+          setHookData(data);
+          setStep("schedule");
+        }}
+      />
+    );
+  }
+
+  if (step === "schedule") {
+    return (
+      <ScheduleScreen
+        stepLabel="Step 2 of 2"
+        onBack={() => setStep("hook")}
+        onComplete={(schedule) => {
+          if (!hookData) return;
           setStep("loading");
-          submitPreferences(data.location, data.categories, data.budget, data.displayName);
+          submitPreferences(
+            hookData,
+            schedule.scheduleWindow,
+            schedule.availableDays,
+            schedule.timeOfDay,
+          );
         }}
       />
     );

--- a/web-service/src/components/person-a-flow.tsx
+++ b/web-service/src/components/person-a-flow.tsx
@@ -7,8 +7,16 @@ import { BudgetIcon } from "./budget-icon";
 import { CategoryIcon } from "./category-icon";
 import { createSessionStatusSync } from "../lib/session-status-sync";
 import { WaitingForPartnerScreen } from "./waiting-for-partner-screen";
+import { ScheduleScreen } from "./schedule-screen";
 import type { WaitingStatus } from "./waiting-for-partner-screen";
-import type { BudgetLevel, Category, Location } from "../lib/types/preference";
+import type {
+  BudgetLevel,
+  Category,
+  DayOfWeek,
+  Location,
+  ScheduleWindow,
+  TimeOfDay,
+} from "../lib/types/preference";
 
 type CreatedSession = {
   readonly id: string;
@@ -46,8 +54,11 @@ const BUDGETS: { value: BudgetLevel; label: string }[] = [
   { value: "UPSCALE", label: "Upscale" },
 ];
 
+type FormStep = "form" | "schedule";
+
 export function PersonAFlow() {
   const router = useRouter();
+  const [formStep, setFormStep] = useState<FormStep>("form");
   const [name, setName] = useState("");
   const [locationLabel, setLocationLabel] = useState("");
   const [location, setLocation] = useState<Location | null>(null);
@@ -105,11 +116,16 @@ export function PersonAFlow() {
     setBudget("MODERATE");
   }
 
-  async function handleCreateSession() {
-    if (!canSubmit) {
-      return;
-    }
+  function handleCreateSession() {
+    if (!canSubmit) return;
+    setFormStep("schedule");
+  }
 
+  async function handleScheduleComplete(schedule: {
+    scheduleWindow?: ScheduleWindow;
+    availableDays?: DayOfWeek[];
+    timeOfDay?: TimeOfDay;
+  }) {
     setSubmitting(true);
     setError(null);
 
@@ -144,6 +160,9 @@ export function PersonAFlow() {
           location: resolvedLocation,
           budget,
           categories,
+          ...(schedule.scheduleWindow ? { scheduleWindow: schedule.scheduleWindow } : {}),
+          ...(schedule.availableDays ? { availableDays: schedule.availableDays } : {}),
+          ...(schedule.timeOfDay ? { timeOfDay: schedule.timeOfDay } : {}),
         }),
       });
       const preferenceBody = await preferenceResponse.json().catch(() => ({}));
@@ -231,6 +250,19 @@ export function PersonAFlow() {
 
     router.push(redirectHref);
   }, [createdSession, createdSessionStatus, router]);
+
+  if (formStep === "schedule" && !createdSession) {
+    return (
+      <ScheduleScreen
+        stepLabel="Almost there"
+        onBack={() => setFormStep("form")}
+        onComplete={(schedule) => {
+          setFormStep("form");
+          handleScheduleComplete(schedule);
+        }}
+      />
+    );
+  }
 
   if (createdSession) {
     const waitingStatus = toWaitingStatus(createdSessionStatus);

--- a/web-service/src/components/schedule-screen.tsx
+++ b/web-service/src/components/schedule-screen.tsx
@@ -16,8 +16,8 @@ type ScheduleScreenProps = {
 
 const WINDOWS: { value: ScheduleWindow; label: string; sub: string }[] = [
   { value: "this_week", label: "This week", sub: "Next 7 days" },
-  { value: "next_week", label: "Next week", sub: "Week after next" },
-  { value: "two_weeks", label: "Two weeks", sub: "Flexible window" },
+  { value: "next_week", label: "Next week", sub: "Upcoming week" },
+  { value: "two_weeks", label: "Two weeks", sub: "Next 14 days" },
   { value: "flexible", label: "Flexible", sub: "Whenever works" },
 ];
 
@@ -80,7 +80,7 @@ export function ScheduleScreen({
         </button>
 
         <h1 className="text-[clamp(2.2rem,7.5vw,3.4rem)] font-semibold leading-[0.95] tracking-[-0.05em] text-text">
-          When works for you?
+          What works for you?
         </h1>
         <p className="mt-3 text-body text-text-secondary">
           All optional — skip anything you don&apos;t care about.

--- a/web-service/src/components/schedule-screen.tsx
+++ b/web-service/src/components/schedule-screen.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "./button";
+import type { DayOfWeek, ScheduleWindow, TimeOfDay } from "../lib/types/preference";
+
+type ScheduleScreenProps = {
+  readonly onComplete: (data: {
+    scheduleWindow?: ScheduleWindow;
+    availableDays?: DayOfWeek[];
+    timeOfDay?: TimeOfDay;
+  }) => void;
+  readonly onBack: () => void;
+  readonly stepLabel?: string;
+};
+
+const WINDOWS: { value: ScheduleWindow; label: string; sub: string }[] = [
+  { value: "this_week", label: "This week", sub: "Next 7 days" },
+  { value: "next_week", label: "Next week", sub: "Week after next" },
+  { value: "two_weeks", label: "Two weeks", sub: "Flexible window" },
+  { value: "flexible", label: "Flexible", sub: "Whenever works" },
+];
+
+const DAYS: { value: DayOfWeek; label: string }[] = [
+  { value: "mon", label: "Mo" },
+  { value: "tue", label: "Tu" },
+  { value: "wed", label: "We" },
+  { value: "thu", label: "Th" },
+  { value: "fri", label: "Fr" },
+  { value: "sat", label: "Sa" },
+  { value: "sun", label: "Su" },
+];
+
+const TIMES: { value: TimeOfDay; label: string; sub: string }[] = [
+  { value: "afternoon", label: "Afternoon", sub: "12 – 5 pm" },
+  { value: "evening", label: "Evening", sub: "5 – 10 pm" },
+  { value: "night", label: "Night", sub: "8 pm – late" },
+  { value: "any", label: "Any time", sub: "No preference" },
+];
+
+export function ScheduleScreen({
+  onComplete,
+  onBack,
+  stepLabel = "Step 3 of 3",
+}: ScheduleScreenProps) {
+  const [window, setWindow] = useState<ScheduleWindow | null>(null);
+  const [days, setDays] = useState<DayOfWeek[]>([]);
+  const [time, setTime] = useState<TimeOfDay | null>(null);
+
+  function toggleDay(day: DayOfWeek) {
+    setDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day],
+    );
+  }
+
+  function handleSubmit() {
+    onComplete({
+      ...(window ? { scheduleWindow: window } : {}),
+      ...(days.length > 0 ? { availableDays: days } : {}),
+      ...(time ? { timeOfDay: time } : {}),
+    });
+  }
+
+  return (
+    <div className="relative flex min-h-dvh flex-col bg-bg px-6 pb-24 pt-6">
+      <div className="mx-auto flex w-full max-w-md flex-1 flex-col">
+        <div className="flex items-center justify-between">
+          <span className="rounded-full border border-white/70 bg-white/80 px-3 py-1 text-caption font-medium text-text-secondary shadow-sm">
+            {stepLabel}
+          </span>
+          <div className="flex gap-1.5">
+            <div className="h-2 w-10 rounded-full bg-secondary" />
+            <div className="h-2 w-10 rounded-full bg-secondary" />
+            <div className="h-2 w-10 rounded-full bg-secondary" />
+          </div>
+        </div>
+
+        <button onClick={onBack} className="cursor-pointer pb-4 pt-4" aria-label="Go back">
+          <BackArrow />
+        </button>
+
+        <h1 className="text-[clamp(2.2rem,7.5vw,3.4rem)] font-semibold leading-[0.95] tracking-[-0.05em] text-text">
+          When works for you?
+        </h1>
+        <p className="mt-3 text-body text-text-secondary">
+          All optional — skip anything you don&apos;t care about.
+        </p>
+
+        <div className="mt-8 space-y-8">
+          {/* Schedule window */}
+          <section>
+            <h2 className="text-body font-semibold text-text">Time frame</h2>
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              {WINDOWS.map(({ value, label, sub }) => {
+                const selected = window === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setWindow(selected ? null : value)}
+                    aria-pressed={selected}
+                    className={`flex h-[72px] cursor-pointer flex-col items-start justify-center rounded-[1.45rem] border-[1.5px] px-4 transition-all duration-200 active:scale-[0.97] ${
+                      selected
+                        ? "border-primary bg-primary text-white"
+                        : "border-muted bg-surface text-text shadow-sm hover:border-text-secondary"
+                    }`}
+                  >
+                    <span className="text-body font-semibold">{label}</span>
+                    <span className={`text-caption ${selected ? "text-white/75" : "text-text-secondary"}`}>
+                      {sub}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Days of week */}
+          <section>
+            <h2 className="text-body font-semibold text-text">Available days</h2>
+            <div className="mt-3 flex gap-2">
+              {DAYS.map(({ value, label }) => {
+                const selected = days.includes(value);
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => toggleDay(value)}
+                    aria-pressed={selected}
+                    className={`flex h-10 flex-1 cursor-pointer items-center justify-center rounded-xl border-[1.5px] text-caption font-semibold transition-all duration-200 active:scale-[0.97] ${
+                      selected
+                        ? "border-primary bg-primary text-white"
+                        : "border-muted bg-surface text-text shadow-sm hover:border-text-secondary"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Time of day */}
+          <section>
+            <h2 className="text-body font-semibold text-text">Time of day</h2>
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              {TIMES.map(({ value, label, sub }) => {
+                const selected = time === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setTime(selected ? null : value)}
+                    aria-pressed={selected}
+                    className={`flex h-[72px] cursor-pointer flex-col items-start justify-center rounded-[1.45rem] border-[1.5px] px-4 transition-all duration-200 active:scale-[0.97] ${
+                      selected
+                        ? "border-secondary bg-secondary-muted text-secondary"
+                        : "border-muted bg-surface text-text shadow-sm hover:border-text-secondary"
+                    }`}
+                  >
+                    <span className="text-body font-semibold">{label}</span>
+                    <span className={`text-caption ${selected ? "text-secondary/75" : "text-text-secondary"}`}>
+                      {sub}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <div className="fixed bottom-0 left-0 right-0 bg-bg/95 px-6 pb-8 pt-4 backdrop-blur">
+        <div className="mx-auto max-w-sm">
+          <Button onClick={handleSubmit}>Continue</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BackArrow() {
+  return (
+    <svg
+      className="h-6 w-6 text-text-secondary"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M19 12H5" />
+      <path d="M12 19l-7-7 7-7" />
+    </svg>
+  );
+}

--- a/web-service/src/lib/services/__tests__/preference-service.test.ts
+++ b/web-service/src/lib/services/__tests__/preference-service.test.ts
@@ -68,6 +68,9 @@ const fakeRow: PreferenceRow = {
   budget: "MODERATE",
   categories: ["RESTAURANT", "BAR"],
   created_at: "2026-03-29T12:00:00Z",
+  schedule_window: null,
+  available_days: null,
+  time_of_day: null,
 };
 
 const fakeRowB: PreferenceRow = {
@@ -78,6 +81,9 @@ const fakeRowB: PreferenceRow = {
   budget: "UPSCALE",
   categories: ["RESTAURANT", "ACTIVITY"],
   created_at: "2026-03-29T13:00:00Z",
+  schedule_window: null,
+  available_days: null,
+  time_of_day: null,
 };
 
 // ---------------------------------------------------------------------------

--- a/web-service/src/lib/services/__tests__/schedule-intersection.test.ts
+++ b/web-service/src/lib/services/__tests__/schedule-intersection.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resolveSchedule } from "../schedule-intersection";
+import type { ScheduleWindow, DayOfWeek, TimeOfDay } from "../../types/preference";
+
+// Pin "now" to a known Monday so day-of-week math is deterministic.
+// 2026-04-27 is a Monday.
+const MONDAY = new Date("2026-04-27T00:00:00.000Z");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(MONDAY);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+type PartialSchedule = {
+  scheduleWindow?: ScheduleWindow;
+  availableDays?: readonly DayOfWeek[];
+  timeOfDay?: TimeOfDay;
+};
+
+function pref(p: PartialSchedule) {
+  return p;
+}
+
+describe("resolveSchedule — window priority", () => {
+  it("uses this_week when both say this_week", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "any" }),
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "any" }),
+    );
+    // this_week from Monday 2026-04-27 → ends Sunday 2026-05-03
+    expect(result.startDate.toISOString().slice(0, 10)).toBe("2026-04-27");
+    expect(result.endDate.toISOString().slice(0, 10)).toBe("2026-05-03");
+  });
+
+  it("uses the earlier window when they differ", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "next_week", availableDays: ["sat"], timeOfDay: "any" }),
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "any" }),
+    );
+    expect(result.startDate.toISOString().slice(0, 10)).toBe("2026-04-27");
+    expect(result.endDate.toISOString().slice(0, 10)).toBe("2026-05-03");
+  });
+
+  it("flexible spans the next 30 days", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "flexible", availableDays: ["sat"], timeOfDay: "any" }),
+      pref({ scheduleWindow: "flexible", availableDays: ["sat"], timeOfDay: "any" }),
+    );
+    expect(result.startDate.toISOString().slice(0, 10)).toBe("2026-04-27");
+    expect(result.endDate.toISOString().slice(0, 10)).toBe("2026-05-27");
+  });
+
+  it("two_weeks spans 14 days", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "two_weeks", availableDays: ["sat"], timeOfDay: "any" }),
+      pref({ scheduleWindow: "two_weeks", availableDays: ["sat"], timeOfDay: "any" }),
+    );
+    expect(result.startDate.toISOString().slice(0, 10)).toBe("2026-04-27");
+    expect(result.endDate.toISOString().slice(0, 10)).toBe("2026-05-10");
+  });
+});
+
+describe("resolveSchedule — day intersection", () => {
+  it("intersects overlapping days", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "this_week", availableDays: ["fri", "sat", "sun"], timeOfDay: "any" }),
+      pref({ scheduleWindow: "this_week", availableDays: ["sat", "sun", "mon"], timeOfDay: "any" }),
+    );
+    expect(result.intersectedDays).toEqual(["sat", "sun"]);
+    expect(result.hasIntersection).toBe(true);
+  });
+
+  it("hasIntersection true even with no overlapping days — falls back to all days", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "this_week", availableDays: ["mon", "tue"], timeOfDay: "any" }),
+      pref({ scheduleWindow: "this_week", availableDays: ["fri", "sat"], timeOfDay: "any" }),
+    );
+    // No day overlap → fall back to all 7 days, but still hasIntersection
+    expect(result.hasIntersection).toBe(true);
+    expect(result.intersectedDays).toHaveLength(7);
+  });
+
+  it("hasIntersection false when both prefs have no schedule data", () => {
+    const result = resolveSchedule(pref({}), pref({}));
+    expect(result.hasIntersection).toBe(false);
+  });
+});
+
+describe("resolveSchedule — time of day", () => {
+  it("prefers specific over any", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "any" }),
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "evening" }),
+    );
+    expect(result.timeRange).toEqual({ start: 17, end: 22 });
+  });
+
+  it("afternoon maps to 12–17", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "afternoon" }),
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "afternoon" }),
+    );
+    expect(result.timeRange).toEqual({ start: 12, end: 17 });
+  });
+
+  it("night maps to 20–00", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "night" }),
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "any" }),
+    );
+    expect(result.timeRange).toEqual({ start: 20, end: 24 });
+  });
+
+  it("any maps to 10–23", () => {
+    const result = resolveSchedule(
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "any" }),
+      pref({ scheduleWindow: "this_week", availableDays: ["sat"], timeOfDay: "any" }),
+    );
+    expect(result.timeRange).toEqual({ start: 10, end: 23 });
+  });
+});

--- a/web-service/src/lib/services/preference-serializer.ts
+++ b/web-service/src/lib/services/preference-serializer.ts
@@ -4,6 +4,9 @@ import type {
   Location,
   BudgetLevel,
   Category,
+  DayOfWeek,
+  ScheduleWindow,
+  TimeOfDay,
 } from "../types/preference";
 
 /**
@@ -18,6 +21,9 @@ export type SerializedPreference = {
   readonly budget: BudgetLevel;
   readonly categories: readonly Category[];
   readonly createdAt: string;
+  readonly scheduleWindow?: ScheduleWindow;
+  readonly availableDays?: readonly DayOfWeek[];
+  readonly timeOfDay?: TimeOfDay;
 };
 
 /**
@@ -33,5 +39,8 @@ export function serializePreference(pref: Preference): SerializedPreference {
     budget: pref.budget,
     categories: pref.categories,
     createdAt: pref.createdAt.toISOString(),
+    ...(pref.scheduleWindow !== undefined ? { scheduleWindow: pref.scheduleWindow } : {}),
+    ...(pref.availableDays !== undefined ? { availableDays: pref.availableDays } : {}),
+    ...(pref.timeOfDay !== undefined ? { timeOfDay: pref.timeOfDay } : {}),
   };
 }

--- a/web-service/src/lib/services/preference-service.ts
+++ b/web-service/src/lib/services/preference-service.ts
@@ -31,6 +31,9 @@ export async function submitPreference(
       location: input.location,
       budget: input.budget,
       categories: [...input.categories],
+      ...(input.scheduleWindow !== undefined ? { schedule_window: input.scheduleWindow } : {}),
+      ...(input.availableDays !== undefined ? { available_days: [...input.availableDays] } : {}),
+      ...(input.timeOfDay !== undefined ? { time_of_day: input.timeOfDay } : {}),
     })
     .select()
     .single<PreferenceRow>();

--- a/web-service/src/lib/services/schedule-intersection.ts
+++ b/web-service/src/lib/services/schedule-intersection.ts
@@ -1,0 +1,138 @@
+import type { DayOfWeek, ScheduleWindow, TimeOfDay } from "../types/preference";
+
+type PartialSchedulePref = {
+  scheduleWindow?: ScheduleWindow;
+  availableDays?: readonly DayOfWeek[];
+  timeOfDay?: TimeOfDay;
+};
+
+type TimeRange = { start: number; end: number };
+
+type ResolveScheduleResult = {
+  startDate: Date;
+  endDate: Date;
+  timeRange: TimeRange;
+  intersectedDays: DayOfWeek[];
+  hasIntersection: boolean;
+};
+
+const ALL_DAYS: DayOfWeek[] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+
+const TIME_RANGES: Record<TimeOfDay, TimeRange> = {
+  afternoon: { start: 12, end: 17 },
+  evening: { start: 17, end: 22 },
+  night: { start: 20, end: 24 },
+  any: { start: 10, end: 23 },
+};
+
+const WINDOW_RANK: Record<ScheduleWindow, number> = {
+  this_week: 0,
+  next_week: 1,
+  two_weeks: 2,
+  flexible: 3,
+};
+
+function addUTCDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+function windowDateRange(window: ScheduleWindow, now: Date): { start: Date; end: Date } {
+  const start = new Date(now);
+  // UTC day-of-week: Mon=0 … Sun=6
+  const utcDow = (now.getUTCDay() + 6) % 7;
+
+  if (window === "this_week") {
+    return { start, end: addUTCDays(start, 6 - utcDow) };
+  }
+
+  if (window === "next_week") {
+    const daysUntilNextMonday = ((7 - utcDow) % 7) || 7;
+    const nextMonday = addUTCDays(start, daysUntilNextMonday);
+    return { start: nextMonday, end: addUTCDays(nextMonday, 6) };
+  }
+
+  if (window === "two_weeks") {
+    return { start, end: addUTCDays(start, 13) };
+  }
+
+  // flexible — 30 days
+  return { start, end: addUTCDays(start, 30) };
+}
+
+function resolveWindow(
+  a: ScheduleWindow | undefined,
+  b: ScheduleWindow | undefined,
+  now: Date,
+): { startDate: Date; endDate: Date } {
+  if (!a && !b) {
+    const end = new Date(now);
+    end.setDate(now.getDate() + 30);
+    return { startDate: now, endDate: end };
+  }
+
+  const winner =
+    a && b
+      ? WINDOW_RANK[a] <= WINDOW_RANK[b]
+        ? a
+        : b
+      : (a ?? b)!;
+
+  const range = windowDateRange(winner, now);
+  return { startDate: range.start, endDate: range.end };
+}
+
+function resolveDays(
+  a: readonly DayOfWeek[] | undefined,
+  b: readonly DayOfWeek[] | undefined,
+): DayOfWeek[] {
+  if (!a || !b) return [...ALL_DAYS];
+  const setB = new Set(b);
+  const intersection = a.filter((d) => setB.has(d));
+  return intersection.length > 0 ? intersection : [...ALL_DAYS];
+}
+
+function resolveTimeRange(
+  a: TimeOfDay | undefined,
+  b: TimeOfDay | undefined,
+): TimeRange {
+  const specific = (t: TimeOfDay | undefined) => t && t !== "any";
+
+  if (specific(a)) return TIME_RANGES[a!];
+  if (specific(b)) return TIME_RANGES[b!];
+  return TIME_RANGES["any"];
+}
+
+export function resolveSchedule(
+  prefA: PartialSchedulePref,
+  prefB: PartialSchedulePref,
+): ResolveScheduleResult {
+  const hasAnyData =
+    prefA.scheduleWindow ||
+    prefA.availableDays ||
+    prefA.timeOfDay ||
+    prefB.scheduleWindow ||
+    prefB.availableDays ||
+    prefB.timeOfDay;
+
+  if (!hasAnyData) {
+    const now = new Date();
+    const end = new Date(now);
+    end.setDate(now.getDate() + 30);
+    return {
+      startDate: now,
+      endDate: end,
+      timeRange: TIME_RANGES["any"],
+      intersectedDays: [],
+      hasIntersection: false,
+    };
+  }
+
+  const now = new Date();
+  const { startDate, endDate } = resolveWindow(prefA.scheduleWindow, prefB.scheduleWindow, now);
+  const intersectedDays = resolveDays(prefA.availableDays, prefB.availableDays);
+  const timeRange = resolveTimeRange(prefA.timeOfDay, prefB.timeOfDay);
+
+  return { startDate, endDate, timeRange, intersectedDays, hasIntersection: true };
+}

--- a/web-service/src/lib/services/schedule-intersection.ts
+++ b/web-service/src/lib/services/schedule-intersection.ts
@@ -67,9 +67,7 @@ function resolveWindow(
   now: Date,
 ): { startDate: Date; endDate: Date } {
   if (!a && !b) {
-    const end = new Date(now);
-    end.setDate(now.getDate() + 30);
-    return { startDate: now, endDate: end };
+    return { startDate: now, endDate: addUTCDays(now, 30) };
   }
 
   const winner =
@@ -87,9 +85,11 @@ function resolveDays(
   a: readonly DayOfWeek[] | undefined,
   b: readonly DayOfWeek[] | undefined,
 ): DayOfWeek[] {
-  if (!a || !b) return [...ALL_DAYS];
-  const setB = new Set(b);
-  const intersection = a.filter((d) => setB.has(d));
+  // Treat undefined as "any day" (all 7) so one-sided input is preserved.
+  const daysA = a ?? ALL_DAYS;
+  const daysB = b ?? ALL_DAYS;
+  const setB = new Set(daysB);
+  const intersection = daysA.filter((d) => setB.has(d));
   return intersection.length > 0 ? intersection : [...ALL_DAYS];
 }
 
@@ -118,11 +118,9 @@ export function resolveSchedule(
 
   if (!hasAnyData) {
     const now = new Date();
-    const end = new Date(now);
-    end.setDate(now.getDate() + 30);
     return {
       startDate: now,
-      endDate: end,
+      endDate: addUTCDays(now, 30),
       timeRange: TIME_RANGES["any"],
       intersectedDays: [],
       hasIntersection: false,

--- a/web-service/src/lib/types/preference.ts
+++ b/web-service/src/lib/types/preference.ts
@@ -17,6 +17,19 @@ export type BudgetLevel = "BUDGET" | "MODERATE" | "UPSCALE";
  */
 export type Category = "RESTAURANT" | "BAR" | "ACTIVITY" | "EVENT";
 
+// ---------------------------------------------------------------------------
+// Schedule preference types (DS-07A)
+// ---------------------------------------------------------------------------
+
+/** Rough time window for when the date should happen. */
+export type ScheduleWindow = "this_week" | "next_week" | "two_weeks" | "flexible";
+
+/** Days of the week a user is available. */
+export type DayOfWeek = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
+
+/** Preferred block of the day. */
+export type TimeOfDay = "afternoon" | "evening" | "night" | "any";
+
 /**
  * A geographic coordinate with a human-readable label.
  * The label is what the user sees ("Downtown Austin", "Current Location")
@@ -40,6 +53,9 @@ export type Preference = {
   readonly budget: BudgetLevel;
   readonly categories: readonly Category[];
   readonly createdAt: Date;
+  readonly scheduleWindow?: ScheduleWindow;
+  readonly availableDays?: readonly DayOfWeek[];
+  readonly timeOfDay?: TimeOfDay;
 };
 
 /**
@@ -51,6 +67,9 @@ export type PreferenceInput = {
   readonly location: Location;
   readonly budget: BudgetLevel;
   readonly categories: readonly Category[];
+  readonly scheduleWindow?: ScheduleWindow;
+  readonly availableDays?: readonly DayOfWeek[];
+  readonly timeOfDay?: TimeOfDay;
 };
 
 // ---------------------------------------------------------------------------
@@ -71,6 +90,9 @@ export type PreferenceRow = {
   readonly budget: BudgetLevel;
   readonly categories: Category[];
   readonly created_at: string;
+  readonly schedule_window: ScheduleWindow | null;
+  readonly available_days: DayOfWeek[] | null;
+  readonly time_of_day: TimeOfDay | null;
 };
 
 /**
@@ -85,6 +107,9 @@ export function toPreference(row: PreferenceRow): Preference {
     budget: row.budget,
     categories: row.categories,
     createdAt: new Date(row.created_at),
+    ...(row.schedule_window ? { scheduleWindow: row.schedule_window } : {}),
+    ...(row.available_days ? { availableDays: row.available_days } : {}),
+    ...(row.time_of_day ? { timeOfDay: row.time_of_day } : {}),
   };
 }
 

--- a/web-service/supabase/migrations/20260424232519_add_schedule_fields_to_preferences.sql
+++ b/web-service/supabase/migrations/20260424232519_add_schedule_fields_to_preferences.sql
@@ -1,0 +1,12 @@
+-- DS-07A: Schedule preference fields
+-- Adds three optional columns used by the Meetup/Ticketmaster event query
+-- pipeline (DS-07B). All nullable so existing preference rows are unaffected.
+
+ALTER TABLE preferences
+  ADD COLUMN IF NOT EXISTS schedule_window TEXT,
+  ADD COLUMN IF NOT EXISTS available_days  TEXT[],
+  ADD COLUMN IF NOT EXISTS time_of_day     TEXT;
+
+-- Allowed values are enforced at the application layer (preference-service /
+-- API route) rather than as CHECK constraints, keeping the schema flexible
+-- for future additions without requiring another migration.


### PR DESCRIPTION
## Summary

- **Migration**: adds `schedule_window`, `available_days`, `time_of_day` nullable columns to `preferences` table (all optional, no existing rows affected)
- **Types**: `ScheduleWindow`, `DayOfWeek`, `TimeOfDay` union types; `Preference`, `PreferenceInput`, and `PreferenceRow` updated with optional/nullable fields
- **`resolveSchedule()` service**: pure function that computes the date window, day intersection, and time range from two partial preference objects — window priority (earlier wins), day fallback (all 7 days if no overlap), time specificity (specific beat `any`)
- **API validation**: preferences POST route validates all three optional fields at the boundary and passes them through to `submitPreference`
- **`ScheduleScreen` component**: third preference screen — time frame picker, day-of-week chip multi-select, time-of-day picker; all fields optional, always-enabled CTA
- **Flow wiring**: `PersonAFlow` shows `ScheduleScreen` after the form before creating the session; `PlanFlow` (Person B) shows it after `HookScreen`

## Test plan

- [ ] `bun run test -- schedule-intersection` — 11 tests covering window priority, day intersection, time of day
- [ ] `bun run test -- "preferences/__tests__/route"` — 35 tests including 5 new schedule validation tests
- [ ] `bun run test` — 475 passing
- [ ] `bun run lint` — no errors
- [ ] `bun run build` — clean build
- [ ] Manually verify `ScheduleScreen` renders correctly in both Person A and Person B flows
- [ ] Verify skipping all schedule fields still submits successfully

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)